### PR TITLE
Publish usage stats on stream finish

### DIFF
--- a/packages/shared/src/__tests__/ai_stream.test.ts
+++ b/packages/shared/src/__tests__/ai_stream.test.ts
@@ -1,0 +1,88 @@
+import { AI } from "../ai";
+import { EventBus } from "../ai/bus";
+import { PromptInput } from "../ai/types";
+import { Identifier } from "../ai/id";
+import { jest, describe, it, expect, beforeAll } from '@jest/globals';
+
+// Mock dependencies
+jest.mock("@ai-sdk/openai", () => ({
+  createOpenAI: jest.fn(() => jest.fn()),
+}));
+jest.mock("@ai-sdk/azure", () => ({
+  createAzure: jest.fn(() => jest.fn()),
+}));
+jest.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: jest.fn(() => jest.fn()),
+}));
+jest.mock("ollama-ai-provider-v2", () => ({
+  createOllama: jest.fn(() => jest.fn()),
+}));
+
+// Mock Identifier
+jest.mock("../ai/id", () => ({
+  Identifier: {
+    ascending: jest.fn(() => "mock-part-id"),
+  },
+}));
+
+describe("AI Stream", () => {
+  let mockEventBus: EventBus;
+
+  beforeAll(() => {
+    mockEventBus = {
+      publish: jest.fn(),
+    } as unknown as EventBus;
+  });
+
+  it("should publish usage stats on stream finish", async () => {
+    const ai = new AI(mockEventBus);
+
+    const input: PromptInput = {
+      sessionID: "session-1",
+      taskID: "task-1",
+      messageID: "message-1",
+      modelId: "openai:gpt-4",
+      context: [],
+      tools: [],
+      message: { role: "user", content: "hello" },
+    };
+
+    const mockUsage = {
+      inputTokens: 10,
+      outputTokens: 20,
+      totalTokens: 30,
+      reasoningTokens: 5,
+      cachedInputTokens: 0,
+    };
+
+    const stream = {
+      fullStream: (async function* () {
+        yield {
+          type: "finish",
+          totalUsage: mockUsage,
+        };
+      })(),
+    } as any;
+
+    const generator = ai.processStream(input, stream);
+
+    // Consume the generator
+    const parts = [];
+    for await (const part of generator) {
+        parts.push(part);
+    }
+
+    // Check if publish was called with message.part.updated and usage type
+    expect(mockEventBus.publish).toHaveBeenCalledWith(
+      "message.part.updated",
+      expect.objectContaining({
+        type: "usage",
+        part: mockUsage,
+        sessionID: input.sessionID,
+        taskID: input.taskID,
+        messageID: input.messageID,
+        partID: "mock-part-id",
+      })
+    );
+  });
+});

--- a/packages/shared/src/ai/index.ts
+++ b/packages/shared/src/ai/index.ts
@@ -344,11 +344,8 @@ export class AI {
               cachedInputTokens: value.totalUsage.cachedInputTokens,
             },
           };
-        // this.eventBus.publish("message.part.updated", usage);
-        // yield usage;
-
-        // TODO: publish usage
-        // this.eventBus.publish("session.updated", usage);
+          this.eventBus.publish("message.part.updated", usage);
+          yield usage;
       }
     }
   }


### PR DESCRIPTION
Implemented the logic to publish usage statistics when the AI stream finishes by uncommenting the relevant code in `packages/shared/src/ai/index.ts`.
Also verified that the event type `message.part.updated` is correct and removed the confusing `session.updated` TODO.
Added a unit test `packages/shared/src/__tests__/ai_stream.test.ts` to ensure the usage stats are published correctly.

---
*PR created automatically by Jules for task [7216306054996493855](https://jules.google.com/task/7216306054996493855) started by @pffreitas*