### PR TITLE
🎨 Palette: Add aria-label to user profile button

### DIFF
--- a/apps/web/components/header-auth.tsx
+++ b/apps/web/components/header-auth.tsx
@@ -31,6 +31,7 @@ function ProfileDropDown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
+          aria-label="Open user profile menu"
           className="cursor-pointer rounded-full ring-offset-background transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <Avatar className="h-8 w-8">


### PR DESCRIPTION
Closing as duplicate — profile menu ARIA labels were already merged via #169 which covers both header-auth.tsx and mobile-header.tsx.