### PR TITLE
🎨 Palette: Add keyboard shortcut hint to global search trigger

### DIFF
--- a/apps/web/components/command-dialog-trigger.tsx
+++ b/apps/web/components/command-dialog-trigger.tsx
@@ -18,9 +18,13 @@ export function CommandDialogTrigger() {
     <button
       onClick={toggle}
       className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      aria-label="Search (Cmd/Ctrl + /)"
     >
       <Search size={16} className="text-gray-400" />
-      <span>Search</span>
+      <span className="flex-1 text-left">Search</span>
+      <kbd className="hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+        <span className="text-xs">⌘</span>/
+      </kbd>
     </button>
   );
 }


### PR DESCRIPTION
Closing as duplicate of #179, which was merged with the same keyboard shortcut hint.