### PR TITLE
🎨 Palette: Add accessible labels to auth inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-17 - Missing ARIA labels on placeholder-only inputs
+**Learning:** Auth forms often rely solely on placeholders for labels (e.g. `placeholder="Email"`), which is a common accessibility anti-pattern as screen readers may not read them reliably and the context is lost when typing. Also found a placeholder mismatch (`"Username"` for `type="email"`).
+**Action:** When working with shadcn `Input` components used without a `<Label>`, always ensure an `aria-label` is present and matches the expected input type to provide accessible names for screen readers.

--- a/apps/web/app/(auth-pages)/forgot-password/page.tsx
+++ b/apps/web/app/(auth-pages)/forgot-password/page.tsx
@@ -45,7 +45,8 @@ export default function ForgotPassword() {
         <Input
           name="email"
           type="email"
-          placeholder="Email"
+          placeholder="Email address"
+          aria-label="Email address"
           required
           className="h-11 rounded-full border-gray-300 px-5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:ring-0"
         />

--- a/apps/web/app/(auth-pages)/sign-in/page.tsx
+++ b/apps/web/app/(auth-pages)/sign-in/page.tsx
@@ -46,7 +46,8 @@ export default function Login() {
           <Input
             name="email"
             type="email"
-            placeholder="Username"
+            placeholder="Email address"
+            aria-label="Email address"
             required
             className="h-11 rounded-full border-gray-300 px-5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:ring-0"
           />
@@ -57,6 +58,7 @@ export default function Login() {
               type={showPassword ? "text" : "password"}
               name="password"
               placeholder="Password"
+              aria-label="Password"
               required
               className="h-11 rounded-full border-gray-300 px-5 pr-11 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:ring-0"
             />

--- a/apps/web/app/(auth-pages)/sign-up/page.tsx
+++ b/apps/web/app/(auth-pages)/sign-up/page.tsx
@@ -53,7 +53,8 @@ export default function Signup() {
         <Input
           name="email"
           type="email"
-          placeholder="Email"
+          placeholder="Email address"
+          aria-label="Email address"
           required
           className="h-11 rounded-full border-gray-300 px-5 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:ring-0"
         />
@@ -64,6 +65,7 @@ export default function Signup() {
             type={showPassword ? "text" : "password"}
             name="password"
             placeholder="Password"
+            aria-label="Password"
             minLength={6}
             required
             className="h-11 rounded-full border-gray-300 px-5 pr-11 text-sm placeholder:text-gray-400 focus:border-gray-400 focus:ring-0"


### PR DESCRIPTION
Closing as duplicate of #167 (auth input ARIA labels). Has bun.lock conflict against current main.