### PR TITLE
🎨 Palette: Add ARIA labels to AI component buttons

### DIFF
--- a/apps/web/components/ai-elements/code-block.tsx
+++ b/apps/web/components/ai-elements/code-block.tsx
@@ -136,6 +136,7 @@ export const CodeBlockCopyButton = ({
 
   return (
     <Button
+      aria-label="Copy code"
       className={cn("shrink-0", className)}
       onClick={copyToClipboard}
       size="icon"

--- a/apps/web/components/ai-elements/prompt-input.tsx
+++ b/apps/web/components/ai-elements/prompt-input.tsx
@@ -622,8 +622,11 @@ export const PromptInputSubmit = ({
     Icon = <XIcon className="size-4" />;
   }
 
+  const ariaLabel = status === "streaming" ? "Stop generation" : "Send prompt";
+
   return (
     <Button
+      aria-label={ariaLabel}
       className={cn("gap-1.5 rounded-lg", className)}
       size={size}
       type="submit"


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the `CodeBlockCopyButton` and `PromptInputSubmit` components.
🎯 Why: These buttons are primarily icon-only and lacked accessible names, making it difficult for screen reader users to understand their function.
📸 Before/After: N/A (Non-visual change)
♿ Accessibility: Improved screen reader support for code copy buttons and chat prompt submission buttons.

---
*PR created automatically by Jules for task [618353075723139574](https://jules.google.com/task/618353075723139574) started by @pffreitas*