### PR TITLE
🎨 Palette: Add ARIA label to search input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Accessible Search Input
+**Learning:** Shadcn `Input` components relying solely on placeholders without `<Label>` tags must explicitly define an `aria-label` for screen reader accessibility.
+**Action:** Always provide an `aria-label` to standalone icon-and-input search combinations.

--- a/apps/web/components/search/search-input.tsx
+++ b/apps/web/components/search/search-input.tsx
@@ -44,6 +44,7 @@ export function SearchInput({
         <Input
           type="text"
           placeholder="Ask a question about your bookmarks..."
+          aria-label="Search your bookmarks"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
Closing as duplicate — the search input ARIA label was already added as part of the merged #167 (which covers search-input.tsx among other files).