### PR TITLE
🎨 Palette: Add keyboard shortcut hint to search trigger

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-04-19 - Client-Side OS Detection for Keyboard Hints
+**Learning:** When displaying OS-specific keyboard shortcuts (like `⌘` vs `Ctrl`), relying on `navigator.platform` during initial render causes SSR hydration mismatch errors in Next.js because the server doesn't know the client's OS.
+**Action:** Initialize OS-specific hint state to a default or empty value and perform the `navigator.platform` check inside a `useEffect` hook to ensure it only runs on the client. Wrap the keys in semantic `<kbd>` tags.

--- a/apps/web/components/command-dialog-trigger.tsx
+++ b/apps/web/components/command-dialog-trigger.tsx
@@ -8,6 +8,11 @@ import { Search } from "lucide-react";
 export function CommandDialogTrigger() {
   const { toggle } = useCommandDialog();
   const isMobile = useIsMobile();
+  const [isMac, setIsMac] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
 
   // Don't render on mobile
   if (isMobile) {
@@ -17,10 +22,16 @@ export function CommandDialogTrigger() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      aria-label={`Search command (${isMac ? "⌘" : "Ctrl"} /)`}
+      className="flex items-center justify-between w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
     >
-      <Search size={16} className="text-gray-400" />
-      <span>Search</span>
+      <div className="flex items-center gap-2">
+        <Search size={16} className="text-gray-400" />
+        <span>Search</span>
+      </div>
+      <kbd className="hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+        <span className="text-xs">{isMac ? "⌘" : "Ctrl"}</span>/
+      </kbd>
     </button>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
Closing as duplicate of #179, which was merged with the same keyboard shortcut hint.