### PR TITLE
fix(worker,shared): harden Twitter scraping and AI summarization pipe…

### DIFF
--- a/apps/worker/src/queue/handlers/bookmark-processor.handler.ts
+++ b/apps/worker/src/queue/handlers/bookmark-processor.handler.ts
@@ -16,8 +16,8 @@ export class BookmarkProcessorHandler implements MessageHandler {
     private readonly bookmarkProcessorService: BookmarkProcessorService,
   ) {}
 
-  canHandle(): boolean {
-    return true;
+  canHandle(messageType: string): boolean {
+    return messageType === "bookmark_process";
   }
 
   async handle(message: QueueMessage): Promise<void> {

--- a/apps/worker/src/queue/queue.processor.ts
+++ b/apps/worker/src/queue/queue.processor.ts
@@ -51,6 +51,13 @@ export class QueueProcessor implements OnModuleInit, OnModuleDestroy {
       `Starting queue processor with ${options.queues.length} queues, concurrency=${options.concurrency}`,
     );
 
+    const configuredNames = options.queues.map((q) => q.name);
+    if (!configuredNames.includes("bookmarks")) {
+      this.logger.warn(
+        `"bookmarks" queue is not in QUEUE_NAMES (${configuredNames.join(", ")}). Bookmark AI processing will not run.`,
+      );
+    }
+
     const limit = pLimit(options.concurrency);
 
     for (const queueConfig of options.queues) {
@@ -225,7 +232,7 @@ export class QueueProcessor implements OnModuleInit, OnModuleDestroy {
 
   private getProcessorOptions(): ProcessorOptions {
     const queueNames = this.configService
-      .get<string>("QUEUE_NAMES", "default")
+      .get<string>("QUEUE_NAMES", "bookmarks")
       .split(",");
     const defaultPollInterval = this.configService.get<number>(
       "QUEUE_POLL_INTERVAL",

--- a/apps/worker/src/queue/queue.service.ts
+++ b/apps/worker/src/queue/queue.service.ts
@@ -42,20 +42,27 @@ export class QueueService {
   }
 
   async popMessages(queueName: string, count: number): Promise<QueueMessage[]> {
+    // Use `read` instead of `pop` so messages stay in the queue with a visibility
+    // timeout. If the worker crashes mid-processing they become visible again
+    // automatically, enabling true retry. Explicit `deleteMessage` / `archiveMessage`
+    // after processing removes them from the queue.
+    const VISIBILITY_TIMEOUT_SECONDS = 300; // 5 min — enough for a full bookmark run
     try {
       const { data, error } = await this.supabaseClient
         .getClient()
         .schema("pgmq_public")
-        .rpc("pop", {
+        .rpc("read", {
           queue_name: queueName,
+          sleep_seconds: VISIBILITY_TIMEOUT_SECONDS,
+          n: count,
         });
 
       if (error) {
         this.logger.error(
-          `Failed to pop messages from queue ${queueName}`,
+          `Failed to read messages from queue ${queueName}`,
           error,
         );
-        throw new Error(`Queue pop failed: ${error.message}`);
+        throw new Error(`Queue read failed: ${error.message}`);
       }
 
       if (!data || data.length === 0) {
@@ -71,7 +78,7 @@ export class QueueService {
       }));
     } catch (error) {
       this.logger.error(
-        `Error popping messages from queue ${queueName}`,
+        `Error reading messages from queue ${queueName}`,
         error,
       );
       throw error;

--- a/packages/apispec/bookmarks.tsp
+++ b/packages/apispec/bookmarks.tsp
@@ -22,6 +22,14 @@ model CollectionPathItem {
     name: string;
 }
 
+@doc("Processing state of AI pipeline for a bookmark")
+enum ProcessingStatus {
+    idle,
+    processing,
+    completed,
+    failed,
+}
+
 model Bookmark {
     id: string;
     sourceUrl: string;
@@ -42,6 +50,10 @@ model Bookmark {
     isLikedByCurrentUser?: boolean;
     isPublic?: boolean;
     shareSlug?: string;
+    processingStatus?: ProcessingStatus;
+    processingStartedAt?: utcDateTime;
+    processingCompletedAt?: utcDateTime;
+    processingError?: string;
 }
 
 model BookmarkImage {

--- a/packages/shared/src/services/bookmark.processor.prompt.ts
+++ b/packages/shared/src/services/bookmark.processor.prompt.ts
@@ -292,6 +292,62 @@ Your task is to generate a compelling brief summary of a YouTube video that help
 3. Output ONLY the summary text. Do NOT include any labels, prefixes, or formatting. Just the plain summary paragraph.
 `;
 
+export const SUMMARIZE_TWEET_PROMPT = `
+You will be creating a concise, insightful summary of a tweet or Twitter thread. Follow these instructions carefully:
+
+<tweet>
+{{CONTENT}}
+</tweet>
+
+Your task is to analyze the tweet and create a compact structured summary:
+
+1. **Read and Analyze**: Understand what the author is saying, arguing, or sharing. Note the author, any quoted content, and engagement context.
+
+2. **Create the Summary**: Generate the following sections:
+   - **Topic**: A short descriptive title (5-10 words) capturing what the tweet is about
+   - **Summary**: 1-2 sentences describing what the author says or argues
+   - **Context**: 1-2 sentences on why this is notable — who said it, what it references, or why it matters
+   - **Key takeaway**: A single sentence with the main insight or claim
+
+3. **Format Requirements**:
+   - Output ONLY in markdown format
+   - Do NOT include any text other than the markdown content
+   - Do NOT wrap the output in code blocks
+   - Use ## for section headers
+
+Your output should follow this structure:
+
+## [Topic]
+
+[Summary sentence(s)]
+
+## Context
+
+[Context sentence(s)]
+
+## Key Takeaway
+
+[Single sentence]
+
+Begin your response immediately with the markdown content.
+`;
+
+export const BRIEF_SUMMARY_TWEET_PROMPT = `
+Your task is to generate a single compelling sentence that captures the essence of this tweet and why it matters.
+
+<tweet>
+{{CONTENT}}
+</tweet>
+
+Requirements:
+- One sentence only (20-40 words)
+- Mention the author or context if it adds value
+- Focus on the core claim, insight, or news
+- Avoid starting with "This tweet..."
+
+Output ONLY the sentence. No labels, prefixes, or formatting.
+`;
+
 export const FILTER_IMAGES_PROMPT = `
 Your task is to filter the images that are not relevant to the content. Follow the instructions below step by step:
 

--- a/packages/shared/src/services/bookmark.processor.service.ts
+++ b/packages/shared/src/services/bookmark.processor.service.ts
@@ -9,6 +9,8 @@ import {
   BRIEF_SUMMARY_PROMPT,
   SUMMARIZE_YOUTUBE_PROMPT,
   BRIEF_SUMMARY_YOUTUBE_PROMPT,
+  SUMMARIZE_TWEET_PROMPT,
+  BRIEF_SUMMARY_TWEET_PROMPT,
 } from "../services/bookmark.processor.prompt";
 import { Session } from "../ai/types";
 import { Identifier } from "../ai/id";
@@ -120,7 +122,10 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
         bookmark
       );
 
-      const images = await this.processImages(session, bookmark, content);
+      // Tweet images are author-attached and always relevant — skip AI filtering.
+      const images = this.isTwitterBookmark(bookmark)
+        ? this.promoteTweetImages(content)
+        : await this.processImages(session, bookmark, content);
       bookmark.cosmicImages = images;
 
       bookmark = await this.bookmarkService.update(bookmark.id, bookmark);
@@ -176,6 +181,18 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
     return bookmark.metadata?.openGraph?.site_name === "YouTube";
   }
 
+  private isTwitterBookmark(bookmark: Bookmark): boolean {
+    return bookmark.metadata?.openGraph?.site_name === "X (formerly Twitter)";
+  }
+
+  private promoteTweetImages(content: ScrapedUrlContents): BookmarkImage[] {
+    return (content.images ?? []).map((img) => ({
+      url: img.url,
+      title: img.alt ?? "Tweet media",
+      description: img.alt ?? "Media attached to the tweet",
+    }));
+  }
+
   private async summarizeContent(
     session: Session,
     bookmark: Bookmark,
@@ -185,8 +202,26 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
     let briefSummary = "";
 
     const isYouTube = this.isYouTubeBookmark(bookmark);
-    const summarizePrompt = isYouTube ? SUMMARIZE_YOUTUBE_PROMPT : SUMMARIZE_PROMPT;
-    const briefPrompt = isYouTube ? BRIEF_SUMMARY_YOUTUBE_PROMPT : BRIEF_SUMMARY_PROMPT;
+    const isTwitter = this.isTwitterBookmark(bookmark);
+
+    let summarizePrompt: string;
+    let briefPrompt: string;
+    if (isTwitter) {
+      summarizePrompt = SUMMARIZE_TWEET_PROMPT;
+      briefPrompt = BRIEF_SUMMARY_TWEET_PROMPT;
+    } else if (isYouTube) {
+      summarizePrompt = SUMMARIZE_YOUTUBE_PROMPT;
+      briefPrompt = BRIEF_SUMMARY_YOUTUBE_PROMPT;
+    } else {
+      summarizePrompt = SUMMARIZE_PROMPT;
+      briefPrompt = BRIEF_SUMMARY_PROMPT;
+    }
+
+    // Twitter content is already plain text. YouTube transcripts are plain text.
+    // Generic pages store raw HTML body — strip it before sending to the AI.
+    const textContent = isTwitter || isYouTube
+      ? (content.content ?? "")
+      : this.chunkingService.stripHtml(content.content ?? "");
 
     const task = await this.ai.newTask(
       session.sessionID,
@@ -206,10 +241,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
         tools: [],
         message: {
           role: "user",
-          content: summarizePrompt.replace(
-            "{{CONTENT}}",
-            content.content ?? ""
-          ),
+          content: summarizePrompt.replace("{{CONTENT}}", textContent),
         },
       })) {
         if (part.type === "text") {
@@ -228,10 +260,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
       briefSummary = await this.ai.generateObject({
         sessionID: session.sessionID,
         modelId: "google/gemini-2.5-flash",
-        prompt: briefPrompt.replace(
-          "{{CONTENT}}",
-          content.content ?? ""
-        ),
+        prompt: briefPrompt.replace("{{CONTENT}}", textContent),
         schema: z.string().describe("The summary of the content"),
       });
     } catch (error) {
@@ -276,7 +305,9 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
           role: "user",
           content: GENERATE_TAGS_PROMPT.replace(
             "{{CONTENT}}",
-            content.content ?? ""
+            this.isTwitterBookmark(bookmark) || this.isYouTubeBookmark(bookmark)
+              ? (content.content ?? "")
+              : this.chunkingService.stripHtml(content.content ?? "")
           ),
         },
       })) {

--- a/packages/shared/src/services/twitter.service.ts
+++ b/packages/shared/src/services/twitter.service.ts
@@ -1,5 +1,44 @@
+import * as cheerio from "cheerio";
 import { HttpClient } from "./http-client";
 import { ScrapedUrlContents } from "../types";
+
+export class TwitterScrapingError extends Error {
+  constructor(
+    message: string,
+    public readonly url: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "TwitterScrapingError";
+  }
+}
+
+interface VxTwitterMedia {
+  type: "image" | "video" | "gif";
+  url: string;
+  thumbnail_url?: string;
+  altText?: string;
+}
+
+interface VxTwitterQuote {
+  text?: string;
+  user_name?: string;
+  user_screen_name?: string;
+}
+
+interface VxTwitterResponse {
+  text?: string;
+  user_name?: string;
+  user_screen_name?: string;
+  date?: string;
+  date_epoch?: number;
+  likes?: number;
+  retweets?: number;
+  replies?: number;
+  media_extended?: VxTwitterMedia[];
+  qrt?: VxTwitterQuote;
+  thread?: Array<{ text?: string }>;
+}
 
 export interface TwitterService {
   isTwitterUrl(url: string): boolean;
@@ -13,12 +52,12 @@ export class TwitterServiceImpl implements TwitterService {
 
   isTwitterUrl(url: string): boolean {
     try {
-      const urlObj = new URL(url);
+      const { hostname } = new URL(url);
       return (
-        urlObj.hostname === "twitter.com" ||
-        urlObj.hostname === "x.com" ||
-        urlObj.hostname === "www.twitter.com" ||
-        urlObj.hostname === "www.x.com"
+        hostname === "twitter.com" ||
+        hostname === "x.com" ||
+        hostname === "www.twitter.com" ||
+        hostname === "www.x.com"
       );
     } catch {
       return false;
@@ -28,37 +67,188 @@ export class TwitterServiceImpl implements TwitterService {
   async scrape(
     url: string
   ): Promise<Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId">> {
-    const urlObj = new URL(url);
-    // Replace x.com or twitter.com with api.vxtwitter.com
-    urlObj.hostname = "api.vxtwitter.com";
+    try {
+      return await this.scrapeViaVxTwitter(url);
+    } catch (primaryError) {
+      console.warn(
+        `[TwitterService] vxTwitter failed for ${url}, trying OG fallback:`,
+        primaryError instanceof Error ? primaryError.message : primaryError
+      );
+      try {
+        return await this.scrapeViaOgFallback(url);
+      } catch (fallbackError) {
+        throw new TwitterScrapingError(
+          `Unable to scrape tweet — vxTwitter API and OG fallback both failed. The tweet may be private or deleted.`,
+          url,
+          fallbackError
+        );
+      }
+    }
+  }
 
-    const response = await this.httpClient.fetch(urlObj.toString());
-    const data = JSON.parse(response.body);
+  private async scrapeViaVxTwitter(
+    url: string
+  ): Promise<Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId">> {
+    const apiUrl = new URL(url);
+    apiUrl.hostname = "api.vxtwitter.com";
 
-    const title = `Tweet by ${data.user_name} (@${data.user_screen_name})`;
-    const content = data.text || "";
+    const response = await this.httpClient.fetch(apiUrl.toString());
 
-    const images = (data.media_extended || [])
-      .filter((m: any) => m.type === "image")
-      .map((m: any) => ({
-        url: m.url,
-        alt: "Tweet media",
-      }));
+    if (!response.ok) {
+      throw new Error(`vxTwitter returned ${response.status}: ${response.statusText}`);
+    }
+
+    const data: VxTwitterResponse = JSON.parse(response.body);
+
+    if (!data.user_screen_name) {
+      throw new Error("vxTwitter response missing user data — tweet may be private or deleted");
+    }
+
+    const title = `Tweet by ${data.user_name ?? data.user_screen_name} (@${data.user_screen_name})`;
+    const content = this.buildStructuredContent(url, data);
+    const images = this.extractMedia(data);
+    const links = this.extractLinks(data);
 
     return {
       title,
       content,
       images,
-      links: [],
+      links,
       metadata: {
         openGraph: {
           title,
-          description: content,
+          description: data.text ?? "",
           url,
           site_name: "X (formerly Twitter)",
         },
-        wordCount: content.split(/\s+/).length,
-        readingTime: Math.ceil(content.split(/\s+/).length / 200) || 1,
+        wordCount: (data.text ?? "").split(/\s+/).filter(Boolean).length,
+        readingTime: 1,
+      },
+    };
+  }
+
+  private buildStructuredContent(url: string, data: VxTwitterResponse): string {
+    const parts: string[] = [];
+
+    const authorLine = data.user_name
+      ? `${data.user_name} (@${data.user_screen_name})`
+      : `@${data.user_screen_name}`;
+    const dateLine = data.date ? ` · ${data.date}` : "";
+    parts.push(`${authorLine}${dateLine}`);
+    parts.push("");
+
+    parts.push(data.text ?? "");
+
+    if (data.qrt?.text) {
+      const quotedAuthor = data.qrt.user_name
+        ? `${data.qrt.user_name} (@${data.qrt.user_screen_name})`
+        : `@${data.qrt.user_screen_name ?? "unknown"}`;
+      parts.push("");
+      parts.push(`[Quoted tweet by ${quotedAuthor}]`);
+      parts.push(data.qrt.text);
+    }
+
+    if (data.thread && data.thread.length > 0) {
+      parts.push("");
+      parts.push("[Thread continues]");
+      for (const threadTweet of data.thread) {
+        if (threadTweet.text) {
+          parts.push(threadTweet.text);
+        }
+      }
+    }
+
+    const engagementParts: string[] = [];
+    if (typeof data.likes === "number") engagementParts.push(`${data.likes} likes`);
+    if (typeof data.retweets === "number") engagementParts.push(`${data.retweets} retweets`);
+    if (typeof data.replies === "number") engagementParts.push(`${data.replies} replies`);
+    if (engagementParts.length > 0) {
+      parts.push("");
+      parts.push(`Engagement: ${engagementParts.join(" · ")}`);
+    }
+
+    parts.push("");
+    parts.push(`Source: ${url}`);
+
+    return parts.join("\n");
+  }
+
+  private extractMedia(
+    data: VxTwitterResponse
+  ): Array<{ url: string; alt: string }> {
+    if (!data.media_extended) return [];
+
+    const images: Array<{ url: string; alt: string }> = [];
+
+    for (const media of data.media_extended) {
+      if (media.type === "image") {
+        images.push({ url: media.url, alt: media.altText ?? "Tweet image" });
+      } else if (media.type === "video" || media.type === "gif") {
+        // Use thumbnail as a representative image; store video URL as a link
+        if (media.thumbnail_url) {
+          images.push({
+            url: media.thumbnail_url,
+            alt: media.type === "gif" ? "Tweet GIF thumbnail" : "Tweet video thumbnail",
+          });
+        }
+      }
+    }
+
+    return images;
+  }
+
+  private extractLinks(
+    data: VxTwitterResponse
+  ): Array<{ url: string; text: string }> {
+    const links: Array<{ url: string; text: string }> = [];
+
+    if (!data.media_extended) return links;
+
+    for (const media of data.media_extended) {
+      if (media.type === "video" || media.type === "gif") {
+        links.push({ url: media.url, text: `Tweet ${media.type}` });
+      }
+    }
+
+    return links;
+  }
+
+  private async scrapeViaOgFallback(
+    url: string
+  ): Promise<Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId">> {
+    const response = await this.httpClient.fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`OG fetch returned ${response.status}`);
+    }
+
+    const $ = cheerio.load(response.body);
+
+    const ogTitle =
+      $('meta[property="og:title"]').attr("content") ??
+      $("title").first().text().trim() ??
+      "Tweet";
+    const ogDescription =
+      $('meta[property="og:description"]').attr("content") ?? "";
+    const ogImage = $('meta[property="og:image"]').attr("content");
+
+    const images = ogImage ? [{ url: ogImage, alt: "Tweet preview" }] : [];
+
+    return {
+      title: ogTitle,
+      content: [ogTitle, "", ogDescription, "", `Source: ${url}`].join("\n"),
+      images,
+      links: [],
+      metadata: {
+        openGraph: {
+          title: ogTitle,
+          description: ogDescription,
+          image: ogImage,
+          url,
+          site_name: "X (formerly Twitter)",
+        },
+        wordCount: ogDescription.split(/\s+/).filter(Boolean).length,
+        readingTime: 1,
       },
     };
   }


### PR DESCRIPTION
…line

- Fix silent bookmark processing failure: QUEUE_NAMES defaulted to "default" instead of "bookmarks", so the worker never consumed bookmark jobs
- Fix popMessages ignoring batch count: switched from pgmq_public.pop to pgmq_public.read with n=count and a 300s visibility timeout, enabling true crash-recovery retry (messages reappear if the worker dies mid-run)
- Fix BookmarkProcessorHandler.canHandle always returning true regardless of message type, causing incorrect routing for any non-bookmark message
- Rewrite TwitterServiceImpl: build structured plain-text content (author, date, engagement stats, quote tweet, thread) so the AI has real context; add video/GIF thumbnail extraction; add two-tier fallback (vxTwitter → OG metadata) with a typed TwitterScrapingError on total failure
- Add SUMMARIZE_TWEET_PROMPT and BRIEF_SUMMARY_TWEET_PROMPT — compact 3-section format (Topic / Context / Key Takeaway) replacing the article template that asked for inapplicable sections on 280-char content
- Add isTwitterBookmark() detection to processor; route tweet summarization to the new prompt; skip AI image filtering for tweets (promote all author-attached media directly to cosmicImages)
- Strip raw HTML body before sending generic pages to AI prompts (summarize and tag generation); Twitter/YouTube content bypasses stripping since it is already plain text
- Add ProcessingStatus enum and processingStatus/processingStartedAt/ processingCompletedAt/processingError fields to Bookmark TypeSpec model; regenerate @cosmic-dolphin/api-client