### PR TITLE
🎨 Palette: Add keyboard shortcut hint to Search trigger

### DIFF
--- a/apps/web/components/command-dialog-trigger.tsx
+++ b/apps/web/components/command-dialog-trigger.tsx
@@ -8,6 +8,14 @@ import { Search } from "lucide-react";
 export function CommandDialogTrigger() {
   const { toggle } = useCommandDialog();
   const isMobile = useIsMobile();
+  const [isMac, setIsMac] = React.useState(false);
+
+  React.useEffect(() => {
+    // Check if the user is on a Mac to show the correct shortcut key
+    if (typeof window !== "undefined") {
+      setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+    }
+  }, []);
 
   // Don't render on mobile
   if (isMobile) {
@@ -17,10 +25,14 @@ export function CommandDialogTrigger() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text group"
+      aria-label="Search (Keyboard shortcut: Command or Control plus forward slash)"
     >
       <Search size={16} className="text-gray-400" />
-      <span>Search</span>
+      <span className="flex-1 text-left">Search</span>
+      <kbd className="hidden sm:inline-flex items-center gap-1 rounded border border-gray-200 bg-gray-50 px-1.5 font-mono text-[10px] font-medium text-gray-500 opacity-100 transition-opacity group-hover:opacity-100">
+        <span className="text-xs">{isMac ? "⌘" : "Ctrl"}</span> /
+      </kbd>
     </button>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
Closing as duplicate of #179, which was merged with the same keyboard shortcut hint.