### PR TITLE
🎨 Palette: Add keyboard shortcut hint to command dialog trigger

### DIFF
--- a/apps/web/components/command-dialog-trigger.tsx
+++ b/apps/web/components/command-dialog-trigger.tsx
@@ -8,6 +8,11 @@ import { Search } from "lucide-react";
 export function CommandDialogTrigger() {
   const { toggle } = useCommandDialog();
   const isMobile = useIsMobile();
+  const [isMac, setIsMac] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
 
   // Don't render on mobile
   if (isMobile) {
@@ -17,10 +22,16 @@ export function CommandDialogTrigger() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      className="flex items-center justify-between w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      aria-label="Search"
     >
-      <Search size={16} className="text-gray-400" />
-      <span>Search</span>
+      <span className="flex items-center gap-2">
+        <Search size={16} className="text-gray-400" />
+        <span>Search</span>
+      </span>
+      <kbd className="hidden sm:inline-flex h-5 items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+        <span className="text-xs">{isMac ? "⌘" : "Ctrl"}</span>/
+      </kbd>
     </button>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
Closing as duplicate of #179, which was merged with the same keyboard shortcut hint.