### PR TITLE
🎨 Palette: Add ARIA labels to profile menu buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-03 - Added ARIA labels to Profile Dropdown Buttons
+**Learning:** Avatar-based profile menu triggers are often missing accessible names, leading to silent or confusing screen reader announcements.
+**Action:** Add `aria-label="Open profile menu"` to any icon-only or avatar-only dropdown triggers to improve keyboard and screen reader accessibility.

--- a/apps/web/components/header-auth.tsx
+++ b/apps/web/components/header-auth.tsx
@@ -31,6 +31,7 @@ function ProfileDropDown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
+          aria-label="Open profile menu"
           className="cursor-pointer rounded-full ring-offset-background transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <Avatar className="h-8 w-8">

--- a/apps/web/components/mobile/mobile-header.tsx
+++ b/apps/web/components/mobile/mobile-header.tsx
@@ -97,6 +97,7 @@ export function MobileHeader({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
+                  aria-label="Open profile menu"
                   className="cursor-pointer rounded-full ring-offset-background transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   <Avatar className="h-9 w-9 shadow-sm">


### PR DESCRIPTION
💡 What: Added `aria-label="Open profile menu"` to the profile dropdown trigger buttons in `apps/web/components/header-auth.tsx` and `apps/web/components/mobile/mobile-header.tsx`.
🎯 Why: These buttons contained only visual `<Avatar>` components with no text, meaning screen readers would announce them vaguely or try to guess the context. The added label clarifies their purpose.
📸 Before/After: N/A (invisible metadata change)
♿ Accessibility: Ensures that screen reader users are provided with a clear, descriptive accessible name ("Open profile menu") when navigating to the profile avatar buttons.

---
*PR created automatically by Jules for task [3550055622872760724](https://jules.google.com/task/3550055622872760724) started by @pffreitas*