### PR TITLE
fix(mobile): fix broken empty state on share-to-bookmark screen

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -96,14 +96,36 @@ function RootLayoutNav() {
 
       console.log('🐬 Cosmic Dolphin received a shared link!');
       console.log('📎 Share Intent Data:', JSON.stringify(shareIntent, null, 2));
-      
+
+      // Extract URL from the intent before resetting it
+      const urlRegex = /(https?:\/\/[^\s,;)]+)/g;
+      const possibleValues = [
+        (shareIntent as any).url,
+        (shareIntent as any).webUrl,
+        (shareIntent as any).text,
+        (shareIntent as any).meta?.url,
+        (shareIntent as any).meta?.webUrl,
+        (shareIntent as any).uri,
+        (shareIntent as any).data,
+      ];
+      let extractedUrl: string | null = null;
+      for (const value of possibleValues) {
+        if (typeof value === 'string' && value.length > 0) {
+          const match = value.match(urlRegex);
+          if (match?.[0]) { extractedUrl = match[0]; break; }
+        }
+      }
+
       // Mark that we've navigated
       hasNavigatedToShare.current = true;
       navigationInProgress.current = true;
-      
-      // Navigate to the share screen to display the link
-      // Use replace to avoid stacking modals
-      router.replace('/share');
+
+      // Navigate to the share screen, passing the URL as a stable param so
+      // share.tsx doesn't need to re-read (and race with) the share intent.
+      const target = extractedUrl
+        ? `/share?url=${encodeURIComponent(extractedUrl)}`
+        : '/share';
+      router.replace(target as any);
     }
   }, [hasShareIntent, shareIntent, pathname, session]);
 

--- a/apps/mobile/app/share.tsx
+++ b/apps/mobile/app/share.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { StyleSheet, View, Pressable, ScrollView, ActivityIndicator, Image, Dimensions } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { useShareIntent } from 'expo-share-intent';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurView } from 'expo-blur';
@@ -13,36 +12,6 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 import { BookmarksAPI, UrlPreviewMetadata } from '@/lib/api';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
-
-// Helper to extract URL from various share intent structures
-function extractUrl(shareIntent: any): string | null {
-  if (!shareIntent) return null;
-  
-  // URL detection regex - avoiding trailing punctuation
-  const urlRegex = /(https?:\/\/[^\s,;)]+)/g;
-  
-  // Try various possible fields where URL might be stored
-  const possibleValues = [
-    shareIntent.url,
-    shareIntent.webUrl, 
-    shareIntent.text,
-    shareIntent.meta?.url,
-    shareIntent.meta?.webUrl,
-    shareIntent.uri,
-    shareIntent.data,
-  ];
-  
-  for (const value of possibleValues) {
-    if (typeof value === 'string' && value.length > 0) {
-      const match = value.match(urlRegex);
-      if (match && match[0]) {
-        return match[0];
-      }
-    }
-  }
-  
-  return null;
-}
 
 // Helper to extract domain from URL
 function extractDomain(url: string): string {
@@ -88,42 +57,33 @@ export default function ShareScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{ url?: string }>();
   const insets = useSafeAreaInsets();
-  const { shareIntent, resetShareIntent, hasShareIntent } = useShareIntent();
-  
+
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isSaved, setIsSaved] = useState(false);
-  
+
+  // Capture the URL once on mount from route params so it stays stable for the
+  // entire lifetime of this screen, regardless of any share intent resets that
+  // happen in _layout.tsx or elsewhere.
+  const [sharedUrl] = useState<string | null>(() => params.url ?? null);
+
   // Preview state
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [previewData, setPreviewData] = useState<UrlPreviewMetadata | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  
+
   const tintColor = useThemeColor({}, 'tint');
   const iconColor = useThemeColor({}, 'icon');
   const backgroundColor = useThemeColor({}, 'background');
   const secondaryBackgroundColor = useThemeColor({}, 'backgroundSecondary');
   const borderColor = useThemeColor({}, 'border');
 
-  // Extract URL from share intent - check multiple possible fields, then fall back to deep link params
-  const sharedUrl = extractUrl(shareIntent) || params.url || null;
-
-  // Reset share intent on unmount if it's still present
-  useEffect(() => {
-    return () => {
-      // We only want to reset it if we're actually leaving the screen
-      // and not just because of a re-render.
-      // However, since this is a top-level route, unmount is usually final.
-      resetShareIntent();
-    };
-  }, []);
-
-  // Fetch preview when URL is available
+  // Fetch preview once when the screen mounts (sharedUrl is stable)
   useEffect(() => {
     if (sharedUrl) {
       fetchPreview(sharedUrl);
     }
-  }, [sharedUrl]);
+  }, []);
 
   const fetchPreview = async (url: string) => {
     setIsLoadingPreview(true);
@@ -142,18 +102,15 @@ export default function ShareScreen() {
   };
 
   const navigateAway = () => {
-    // Reset share intent first, then navigate after a small delay
-    resetShareIntent();
-    
-    setTimeout(() => {
-      // Use replace if we can, but since this is usually a modal, 
-      // sometimes we need to just go back or to home
-      if (router.canGoBack()) {
-        router.back();
-      } else {
-        router.replace('/(tabs)');
-      }
-    }, 50);
+    // Navigate immediately — do NOT reset the share intent here because that
+    // clears shareIntent in the provider synchronously, causing a re-render that
+    // shows the empty state while the screen is still visible. _layout.tsx owns
+    // the share intent lifecycle and will reset it via its own effects.
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/(tabs)');
+    }
   };
 
   const handleClose = () => {
@@ -172,11 +129,9 @@ export default function ShareScreen() {
     try {
       await BookmarksAPI.create({ source_url: sharedUrl });
       setIsSaved(true);
-      
+
       // Brief delay to show success state before closing
-      setTimeout(() => {
-        navigateAway();
-      }, 800);
+      setTimeout(navigateAway, 800);
     } catch (error) {
       console.error('Error saving bookmark:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to save bookmark';


### PR DESCRIPTION
## Summary

Fixes the broken state shown in the share sheet after saving a bookmark via iOS share extension. The screen was showing `{ files: null, text: null, webUrl: null, type: null }` and "No link was shared" instead of navigating to the library.

Three bugs were found and fixed:

- **Bug 1 — Premature `resetShareIntent()` before navigation**: `navigateAway()` in `share.tsx` called `resetShareIntent()` synchronously before the 50ms navigation timeout. This immediately cleared the `ShareIntentProvider` state, causing `sharedUrl` (computed inline from the live hook) to become `null`, re-rendering the screen into the empty state while it was still visible to the user.

- **Bug 2 — URL not passed as route param**: `_layout.tsx` navigated to `/share` with no URL (`router.replace('/share')`), so `params.url` was always `undefined` in `share.tsx`. The URL was only accessible through the volatile live `shareIntent` hook, which could be reset at any time (e.g. `resetOnBackground`, previous unmount cleanup).

- **Bug 3 — `sharedUrl` derived from volatile hook state**: `sharedUrl` was computed inline on every render from the live `useShareIntent()` result. Any external reset of the intent — even from `_layout.tsx`'s own effects — would immediately null it out mid-session, even while the user was looking at the preview card.

**Fix approach:**
- `_layout.tsx` now extracts the URL from the share intent *before* navigating and passes it as a stable query param: `router.replace('/share?url=...')`.
- `share.tsx` captures the URL once at mount via `useState` lazy initializer (`() => params.url ?? null`), removing all dependency on the live share intent hook.
- `share.tsx` no longer imports or calls `useShareIntent` at all — `_layout.tsx` owns the intent lifecycle.
- `navigateAway()` navigates directly without calling `resetShareIntent()`.

## Test plan

- [ ] Share a URL from Safari/Chrome to the app → share sheet opens with the correct URL and preview card
- [ ] Tap "Save Bookmark" → success checkmark shows for ~800ms, then navigates to the library (no empty state flash)
- [ ] Tap "Maybe later" / close → dismisses cleanly with no empty state flash
- [ ] Open app normally (not via share) → tabs load as expected, no share screen shown
- [ ] Share a URL while not logged in → redirected to sign-in, then to share screen after auth

https://claude.ai/code/session_016Ty4W7mfwRJQKLpKY5vUez

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ty4W7mfwRJQKLpKY5vUez)_