### PR TITLE
🎨 Palette: Add keyboard shortcut hint to search button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-06 - Add keyboard shortcut hints with kbd tags
+**Learning:** When adding keyboard shortcuts to the UI, explicitly wrapping them in semantic <kbd> tags is critical for screen readers, and client-side OS detection is required to display the correct modifier key (⌘ vs Ctrl) without causing SSR hydration mismatches.
+**Action:** Always wrap shortcut indicators like "⌘ /" in <kbd> tags and use useEffect for OS-specific rendering in Next.js.

--- a/apps/web/components/command-dialog-trigger.tsx
+++ b/apps/web/components/command-dialog-trigger.tsx
@@ -14,13 +14,31 @@ export function CommandDialogTrigger() {
     return null;
   }
 
+  const [modifierKey, setModifierKey] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    // Determine modifier key based on OS (Mac vs Windows/Linux)
+    const isMac = typeof window !== "undefined" && navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+    setModifierKey(isMac ? "⌘" : "Ctrl");
+  }, []);
+
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      aria-label="Search"
+      className="flex items-center justify-between w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
     >
-      <Search size={16} className="text-gray-400" />
-      <span>Search</span>
+      <div className="flex items-center gap-2">
+        <Search size={16} className="text-gray-400" />
+        <span>Search</span>
+      </div>
+      {modifierKey && (
+        <span className="text-xs text-gray-400 font-mono">
+          <kbd className="font-sans px-1 rounded-sm bg-gray-100 border border-gray-200">{modifierKey}</kbd>
+          <span className="mx-0.5"></span>
+          <kbd className="font-sans px-1 rounded-sm bg-gray-100 border border-gray-200">/</kbd>
+        </span>
+      )}
     </button>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
Closing as duplicate of #179, which was merged with the same keyboard shortcut hint (and with correct React hooks ordering).