### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label to external link icon

### DIFF
--- a/apps/web/components/search/search-result-card.tsx
+++ b/apps/web/components/search/search-result-card.tsx
@@ -49,6 +49,7 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label="Open original source in new tab"
               >
                 <ExternalLink className="h-3 w-3" />
               </a>


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute to the anchor tag wrapping the `<ExternalLink />` icon in `SearchResultCard`.
🎯 Why: The anchor tag previously only contained a visual icon component, making its purpose unclear to screen reader users.
📸 Before/After: Visual appearance remains identical.
♿ Accessibility: Screen readers now correctly announce "Open original source in new tab" instead of just "link" or reading out the raw URL, significantly improving navigation context for visually impaired users.

---
*PR created automatically by Jules for task [301828599985660605](https://jules.google.com/task/301828599985660605) started by @pffreitas*