### PR TITLE
🎨 Palette: Add OS-aware keyboard shortcut hint to Search trigger

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
+**Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
+**Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.

--- a/apps/web/components/command-dialog-trigger.tsx
+++ b/apps/web/components/command-dialog-trigger.tsx
@@ -8,6 +8,11 @@ import { Search } from "lucide-react";
 export function CommandDialogTrigger() {
   const { toggle } = useCommandDialog();
   const isMobile = useIsMobile();
+  const [isMac, setIsMac] = React.useState<boolean | null>(null);
+
+  React.useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
 
   // Don't render on mobile
   if (isMobile) {
@@ -17,10 +22,22 @@ export function CommandDialogTrigger() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-2 w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
+      className="flex items-center justify-between w-48 px-3 py-2 text-sm text-muted-foreground bg-white border border-gray-300 rounded-lg hover:border-gray-400 transition-colors cursor-text"
     >
-      <Search size={16} className="text-gray-400" />
-      <span>Search</span>
+      <div className="flex items-center gap-2">
+        <Search size={16} className="text-gray-400" />
+        <span>Search</span>
+      </div>
+      {isMac !== null && (
+        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+          <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+            {isMac ? "⌘" : "Ctrl"}
+          </kbd>
+          <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+            /
+          </kbd>
+        </span>
+      )}
     </button>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
💡 **What:** Added an OS-aware keyboard shortcut hint ("⌘ /" or "Ctrl /") to the global Search trigger button (`CommandDialogTrigger`).
🎯 **Why:** To improve discoverability of the global search shortcut, which is a key power-user feature, helping users navigate more efficiently.
📸 **Before/After:** The button now displays a right-aligned shortcut hint using distinct, grey-bordered pill styling.
♿ **Accessibility:** Wrapped the modifier key and the slash key in semantic `<kbd>` tags, which helps screen readers appropriately announce them as keyboard inputs rather than standard text.

---
*PR created automatically by Jules for task [16337321190318910483](https://jules.google.com/task/16337321190318910483) started by @pffreitas*