### PR TITLE
🎨 Palette: Add Keyboard Shortcut Hint to Primary Action Buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2026-05-11 - Add Keyboard Shortcut Hint to Primary Action Buttons
+**Learning:** Users often don't realize there are keyboard shortcuts for primary actions (like 'Save Bookmark') unless they are explicitly displayed. However, these shortcuts need to be conditionally rendered after SSR to prevent hydration errors and use semantic HTML.
+**Action:** Add visual keyboard shortcut hints (using `<kbd>` tags) directly inside the primary action buttons, conditionally checking `isMac` state after mounting, similar to how the search dialog trigger does it.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -19,18 +19,23 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
-    (state) => state.bookmarks.createLoading
+    (state) => state.bookmarks.createLoading,
   );
   const previewLoading = useAppSelector(
-    (state) => state.bookmarks.previewLoading
+    (state) => state.bookmarks.previewLoading,
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
 
   const isLoading = createLoading || previewLoading;
+
+  useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
 
   const handleSubmit = async () => {
     dispatch(clearErrors());
@@ -41,9 +46,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
       const preview = result.payload as PreviewResponse;
 
       if (preview.scrapable) {
-        const createResult = await dispatch(
-          createBookmark({ sourceUrl: url })
-        );
+        const createResult = await dispatch(createBookmark({ sourceUrl: url }));
         if (createBookmark.fulfilled.match(createResult)) {
           setShowOverlay(false);
           setUrl("");
@@ -77,7 +80,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -143,7 +146,19 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         }}
       >
         <Bookmark size={16} />
-        Save Bookmark
+        <div className="flex items-center gap-2">
+          <span>Save Bookmark</span>
+          {isMac !== null && (
+            <span className="flex items-center gap-1 text-xs text-white/70">
+              <kbd className="font-sans px-1.5 py-0.5 rounded-md border border-white/20 bg-white/10">
+                {isMac ? "⌘" : "Ctrl"}
+              </kbd>
+              <kbd className="font-sans px-1.5 py-0.5 rounded-md border border-white/20 bg-white/10">
+                K
+              </kbd>
+            </span>
+          )}
+        </div>
       </button>
     </>
   );


### PR DESCRIPTION
💡 What: Added visual keyboard shortcut hint (`⌘ K` or `Ctrl K`) inside the "Save Bookmark" primary action button and fixed shortcut listener to support Ctrl.
🎯 Why: Primary action keyboard shortcuts were completely undiscoverable. This makes the feature obvious without cluttering the UI. Also, the shortcut previously only worked on Mac (`metaKey`), now correctly supports Windows/Linux (`ctrlKey`).
📸 Before/After: The Save Bookmark button now displays the OS-appropriate shortcut hint.
♿ Accessibility: Uses semantic `<kbd>` tags for the shortcut hints, providing better screen reader support and visual distinction. Safe OS detection inside `useEffect` prevents hydration mismatches.

---
*PR created automatically by Jules for task [16812625330531568895](https://jules.google.com/task/16812625330531568895) started by @pffreitas*