### PR TITLE
🛡️ Sentinel: [HIGH] Fix Server-Side Request Forgery (SSRF) vulnerability in URL scraping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2026-05-12 - Unrestricted URL Fetching Leading to SSRF
+**Vulnerability:** The web scraping service accepted any syntactically valid HTTP/HTTPS URL, allowing users to request internal network addresses (like `localhost` or cloud metadata at `169.254.169.254`).
+**Learning:** Using `new URL()` alone only validates syntax. Node.js automatically normalizes alternative IP formats (e.g., `http://2130706433/` becomes `127.0.0.1`), meaning we can reliably check the parsed `hostname` property against known private/internal ranges to prevent Server-Side Request Forgery.
+**Prevention:** Always validate parsed URL hostnames against a blocklist of local domains, IPv4 private blocks, and IPv6 local/ULA addresses before making outbound HTTP requests on behalf of users.

--- a/packages/shared/src/__tests__/services/web-scraping.service.test.ts
+++ b/packages/shared/src/__tests__/services/web-scraping.service.test.ts
@@ -25,19 +25,54 @@ describe("WebScrapingService", () => {
     webScrapingService = new WebScrapingServiceImpl(
       mockHttpClient,
       mockYouTubeService,
-      mockTwitterService
+      mockTwitterService,
     );
+  });
+
+  describe("isValidUrl", () => {
+    it("should accept valid external URLs", () => {
+      expect(webScrapingService.isValidUrl("https://example.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://8.8.8.8")).toBe(true);
+    });
+
+    it("should reject internal SSRF URLs", () => {
+      const internalUrls = [
+        "http://localhost",
+        "http://127.0.0.1",
+        "http://0.0.0.0",
+        "http://169.254.169.254",
+        "http://2130706433",
+        "http://0x7f.0.0.1",
+        "http://[::1]",
+      ];
+      internalUrls.forEach((url) => {
+        expect(webScrapingService.isValidUrl(url)).toBe(false);
+      });
+    });
+
+    it("should reject invalid protocols", () => {
+      expect(webScrapingService.isValidUrl("ftp://example.com")).toBe(false);
+      expect(webScrapingService.isValidUrl("file:///etc/passwd")).toBe(false);
+    });
   });
 
   describe("scrape", () => {
     it("should route twitter URLs to TwitterService", async () => {
       mockTwitterService.isTwitterUrl.mockReturnValue(true);
-      mockTwitterService.scrape.mockResolvedValue({ title: "Twitter Test" } as any);
+      mockTwitterService.scrape.mockResolvedValue({
+        title: "Twitter Test",
+      } as any);
 
-      const result = await webScrapingService.scrape("https://x.com/user/status/123");
+      const result = await webScrapingService.scrape(
+        "https://x.com/user/status/123",
+      );
 
-      expect(mockTwitterService.isTwitterUrl).toHaveBeenCalledWith("https://x.com/user/status/123");
-      expect(mockTwitterService.scrape).toHaveBeenCalledWith("https://x.com/user/status/123");
+      expect(mockTwitterService.isTwitterUrl).toHaveBeenCalledWith(
+        "https://x.com/user/status/123",
+      );
+      expect(mockTwitterService.scrape).toHaveBeenCalledWith(
+        "https://x.com/user/status/123",
+      );
       expect(result.title).toBe("Twitter Test");
     });
 
@@ -53,8 +88,12 @@ describe("WebScrapingService", () => {
 
       const result = await webScrapingService.scrape("https://example.com");
 
-      expect(mockYouTubeService.isYouTubeUrl).toHaveBeenCalledWith("https://example.com");
-      expect(mockTwitterService.isTwitterUrl).toHaveBeenCalledWith("https://example.com");
+      expect(mockYouTubeService.isYouTubeUrl).toHaveBeenCalledWith(
+        "https://example.com",
+      );
+      expect(mockTwitterService.isTwitterUrl).toHaveBeenCalledWith(
+        "https://example.com",
+      );
       expect(result.title).toBe("Regular Page");
     });
   });

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -13,13 +13,13 @@ import { TwitterService, TwitterServiceImpl } from "./twitter.service";
 export interface WebScrapingService {
   isValidUrl(url: string): boolean;
   scrape(
-    url: string
+    url: string,
   ): Promise<
     Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId">
   >;
   scrapeContent(
     url: string,
-    content: string
+    content: string,
   ): Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId">;
   extractMetadataFromUrl(url: string): PreviewMetadata;
 }
@@ -31,23 +31,58 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   constructor(
     private httpClient: HttpClient = new CosmicHttpClient(),
     youtubeService?: YouTubeService,
-    twitterService?: TwitterService
+    twitterService?: TwitterService,
   ) {
     this.youtubeService = youtubeService ?? new YouTubeServiceImpl(httpClient);
     this.twitterService = twitterService ?? new TwitterServiceImpl(httpClient);
   }
 
+  // 🛡️ Sentinel: Prevent Server-Side Request Forgery (SSRF) by blocking internal network access
+  private isInternalHostname(hostname: string): boolean {
+    if (!hostname) return true;
+
+    const normalized = hostname.toLowerCase().replace(/\.$/, "");
+
+    if (
+      normalized === "localhost" ||
+      normalized.endsWith(".localhost") ||
+      normalized === "0.0.0.0" ||
+      normalized === "[::]" ||
+      normalized === "[::1]" ||
+      normalized.endsWith(".local") ||
+      normalized.endsWith(".internal")
+    ) {
+      return true;
+    }
+
+    if (/^127\.\d+\.\d+\.\d+$/.test(normalized)) return true;
+    if (/^10\.\d+\.\d+\.\d+$/.test(normalized)) return true;
+    if (/^172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+$/.test(normalized)) return true;
+    if (/^192\.168\.\d+\.\d+$/.test(normalized)) return true;
+    if (/^169\.254\.\d+\.\d+$/.test(normalized)) return true;
+
+    if (normalized.startsWith("[fd") || normalized.startsWith("[fc"))
+      return true; // ULA
+    if (normalized.startsWith("[fe80")) return true; // Link-local
+    if (normalized === "[::1]") return true;
+
+    return false;
+  }
+
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+      return !this.isInternalHostname(urlObj.hostname);
     } catch {
       return false;
     }
   }
 
   async scrape(
-    url: string
+    url: string,
   ): Promise<
     Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId">
   > {
@@ -92,43 +127,53 @@ export class WebScrapingServiceImpl implements WebScrapingService {
     const finalPath = new URL(finalUrl).pathname.toLowerCase();
 
     const authPathPatterns = [
-      "/login", "/signin", "/sign-in", "/sign_in",
-      "/auth", "/oauth", "/sso",
-      "/accounts/login", "/session/new",
-      "/cas/login", "/saml",
+      "/login",
+      "/signin",
+      "/sign-in",
+      "/sign_in",
+      "/auth",
+      "/oauth",
+      "/sso",
+      "/accounts/login",
+      "/session/new",
+      "/cas/login",
+      "/saml",
     ];
 
     const ssoProviders = [
-      "login.microsoftonline.com", "accounts.google.com",
-      "auth0.com", "okta.com", "onelogin.com",
-      "login.salesforce.com", "idp.",
+      "login.microsoftonline.com",
+      "accounts.google.com",
+      "auth0.com",
+      "okta.com",
+      "onelogin.com",
+      "login.salesforce.com",
+      "idp.",
     ];
 
     if (originalHost !== finalHost) {
-      const isSsoRedirect = ssoProviders.some(
-        (provider) => finalHost.includes(provider)
+      const isSsoRedirect = ssoProviders.some((provider) =>
+        finalHost.includes(provider),
       );
       if (isSsoRedirect) {
         throw new Error(
-          `Auth redirect detected: redirected to SSO provider ${finalHost}`
+          `Auth redirect detected: redirected to SSO provider ${finalHost}`,
         );
       }
     }
 
     const isAuthPath = authPathPatterns.some((pattern) =>
-      finalPath.startsWith(pattern)
+      finalPath.startsWith(pattern),
     );
     if (isAuthPath) {
       throw new Error(
-        `Auth redirect detected: redirected to login page ${finalUrl}`
+        `Auth redirect detected: redirected to login page ${finalUrl}`,
       );
     }
   }
 
-
   scrapeContent(
     url: string,
-    content: string
+    content: string,
   ): Omit<ScrapedUrlContents, "id" | "createdAt" | "updatedAt" | "bookmarkId"> {
     const $ = cheerio.load(content);
     $("script").remove();
@@ -201,16 +246,16 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   extractMetadataFromUrl(url: string): PreviewMetadata {
     const urlObj = new URL(url);
     const hostname = urlObj.hostname.replace(/^www\./, "");
-    const siteName = hostname.split(".")[0].charAt(0).toUpperCase() + hostname.split(".")[0].slice(1);
+    const siteName =
+      hostname.split(".")[0].charAt(0).toUpperCase() +
+      hostname.split(".")[0].slice(1);
 
     const pathSegments = urlObj.pathname.split("/").filter(Boolean);
     let title: string | undefined;
     if (pathSegments.length > 0) {
       title = pathSegments
         .map((seg) =>
-          seg
-            .replace(/[-_]/g, " ")
-            .replace(/\b\w/g, (c) => c.toUpperCase())
+          seg.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
         )
         .join(" / ");
     }
@@ -225,7 +270,7 @@ export class WebScrapingServiceImpl implements WebScrapingService {
 
   private extractOpenGraphMetadata(
     sourceUrl: string,
-    $: CheerioAPI
+    $: CheerioAPI,
   ): OpenGraphMetadata {
     const ogData: OpenGraphMetadata = {};
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `WebScrapingService` accepted any syntactically valid HTTP/HTTPS URL, allowing users to request internal network addresses (e.g., `localhost`, `127.0.0.1`, `169.254.169.254`).
🎯 Impact: Attackers could exploit this SSRF vulnerability to bypass firewalls and access internal services, read sensitive cloud metadata (e.g., AWS IAM credentials at `169.254.169.254`), or scan internal networks.
🔧 Fix: Implemented an `isInternalHostname` method within `WebScrapingServiceImpl` to explicitly block resolutions to known private IP blocks (RFC 1918), loopback addresses, link-local addresses, and internal domains (`.local`, `.internal`). Leverages Node's native `URL` parser to automatically handle format normalization (e.g., decimal IP evasions like `2130706433`).
✅ Verification: Added comprehensive unit tests in `web-scraping.service.test.ts` to assert internal URLs are rejected while external domains remain functional. All tests pass successfully.

---
*PR created automatically by Jules for task [5247569375383492997](https://jules.google.com/task/5247569375383492997) started by @pffreitas*