### PR TITLE
🎨 Palette: Cross-platform keyboard shortcuts for new bookmark

### DIFF
--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -18,14 +18,15 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [showOverlay, setShowOverlay] = useState(false);
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
-    (state) => state.bookmarks.createLoading
+    (state) => state.bookmarks.createLoading,
   );
   const previewLoading = useAppSelector(
-    (state) => state.bookmarks.previewLoading
+    (state) => state.bookmarks.previewLoading,
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
@@ -41,9 +42,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
       const preview = result.payload as PreviewResponse;
 
       if (preview.scrapable) {
-        const createResult = await dispatch(
-          createBookmark({ sourceUrl: url })
-        );
+        const createResult = await dispatch(createBookmark({ sourceUrl: url }));
         if (createBookmark.fulfilled.match(createResult)) {
           setShowOverlay(false);
           setUrl("");
@@ -76,8 +75,10 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -142,8 +143,20 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
           handleNewBookmark();
         }}
       >
-        <Bookmark size={16} />
-        Save Bookmark
+        <div className="flex items-center gap-2">
+          <Bookmark size={16} />
+          Save Bookmark
+        </div>
+        {isMac !== null && (
+          <span className="flex items-center gap-1 text-xs text-blue-200 ml-2">
+            <kbd className="font-sans px-1.5 py-0.5 rounded-md border border-blue-400 bg-blue-700/50">
+              {isMac ? "⌘" : "Ctrl"}
+            </kbd>
+            <kbd className="font-sans px-1.5 py-0.5 rounded-md border border-blue-400 bg-blue-700/50">
+              K
+            </kbd>
+          </span>
+        )}
       </button>
     </>
   );


### PR DESCRIPTION
💡 What: Added a visual `<kbd>` hint (`⌘ K` or `Ctrl K`) to the "Save Bookmark" button and updated the global keydown event listener to also support `Ctrl + K` on non-Mac devices.
🎯 Why: Previously, only `Meta + K` triggered the action, alienating non-Mac users. Showing the shortcut visually teaches users power-user workflows and adding cross-platform support significantly improves accessibility and intuitiveness for all users.
📸 Before/After: Visual changes were captured and verified via Playwright screenshot where `⌘ K` now appears inside the save bookmark button on Mac devices.
♿ Accessibility: The OS detection handles SSR safely by initializing inside a `useEffect`. Wrapped the shortcut hints in semantic `<kbd>` tags for correct markup and styling. Expanded event listener from `event.metaKey` to `event.metaKey || event.ctrlKey` to be cross-platform friendly.

---
*PR created automatically by Jules for task [5507265471704262302](https://jules.google.com/task/5507265471704262302) started by @pffreitas*