### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in web scraper

### DIFF
--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,7 +40,41 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      // 🛡️ Sentinel: Block internal/private IP addresses to prevent Server-Side Request Forgery (SSRF) when scraping
+      const hostname = urlObj.hostname;
+
+      // First check for exact localhost/metadata matches
+      if (
+        hostname === "localhost" ||
+        hostname === "[::1]" ||
+        hostname === "169.254.169.254" ||
+        hostname === "0.0.0.0"
+      ) {
+        return false;
+      }
+
+      // If the hostname is an IPv4 address, check for private and loopback ranges
+      const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+      const match = hostname.match(ipv4Regex);
+      if (match) {
+        const octet1 = parseInt(match[1], 10);
+        const octet2 = parseInt(match[2], 10);
+
+        if (
+          octet1 === 127 || // 127.0.0.0/8 (Loopback)
+          octet1 === 10 || // 10.0.0.0/8
+          (octet1 === 172 && octet2 >= 16 && octet2 <= 31) || // 172.16.0.0/12
+          (octet1 === 192 && octet2 === 168) // 192.168.0.0/16
+        ) {
+          return false;
+        }
+      }
+
+      return true;
     } catch {
       return false;
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `isValidUrl` function only checked if a URL protocol was HTTP/HTTPS, allowing users to submit URLs pointing to internal networks, localhost, or cloud provider metadata services (like AWS's `169.254.169.254`). Because the backend blindly fetched these URLs during bookmark processing, it was vulnerable to Server-Side Request Forgery (SSRF).
🎯 Impact: An attacker could map the internal network, access internal APIs, read cloud instance metadata (which can sometimes contain sensitive credentials), or access internal loopback services not protected by external firewalls.
🔧 Fix: Updated the `isValidUrl` method in `web-scraping.service.ts` to parse the URL and explicitly block common internal, loopback, and private IPv4 ranges before any HTTP requests are made.
✅ Verification: `isValidUrl` logic was verified against loopback, private ranges, and public IPs. The TypeScript compiler and existing tests for `@cosmic-dolphin/api` run cleanly without regressions. Added a critical learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11627519548590260449](https://jules.google.com/task/11627519548590260449) started by @pffreitas*