### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcut hint to save bookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2024-05-20 - Cross-Platform Keyboard Shortcuts
+**Learning:** Next.js React components need client-side OS detection to show the correct keyboard shortcut keys, but it must be initialized as `null` or `false` and set in a `useEffect` to avoid SSR hydration mismatch errors.
+**Action:** Always check `event.metaKey || event.ctrlKey` in keydown listeners for cross-platform support, and use `isMac !== null` state to render `⌘` or `Ctrl` wrapped in semantic `<kbd>` tags.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -19,13 +19,14 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
-    (state) => state.bookmarks.createLoading
+    (state) => state.bookmarks.createLoading,
   );
   const previewLoading = useAppSelector(
-    (state) => state.bookmarks.previewLoading
+    (state) => state.bookmarks.previewLoading,
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
@@ -41,9 +42,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
       const preview = result.payload as PreviewResponse;
 
       if (preview.scrapable) {
-        const createResult = await dispatch(
-          createBookmark({ sourceUrl: url })
-        );
+        const createResult = await dispatch(createBookmark({ sourceUrl: url }));
         if (createBookmark.fulfilled.match(createResult)) {
           setShowOverlay(false);
           setUrl("");
@@ -76,8 +75,10 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -108,6 +109,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
                   value={url}
                   autoFocus={true}
                   disabled={isLoading}
+                  aria-label="Bookmark URL"
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !isLoading) {
                       handleSubmit();
@@ -142,8 +144,20 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
           handleNewBookmark();
         }}
       >
-        <Bookmark size={16} />
-        Save Bookmark
+        <div className="flex items-center gap-2">
+          <Bookmark size={16} />
+          <span>Save Bookmark</span>
+        </div>
+        {isMac !== null && (
+          <span className="flex items-center gap-1 text-xs text-blue-200 ml-2">
+            <kbd className="font-sans px-1.5 py-0.5 rounded-md bg-blue-700/50">
+              {isMac ? "⌘" : "Ctrl"}
+            </kbd>
+            <kbd className="font-sans px-1.5 py-0.5 rounded-md bg-blue-700/50">
+              K
+            </kbd>
+          </span>
+        )}
       </button>
     </>
   );


### PR DESCRIPTION
💡 What: Added cross-platform keyboard shortcut hints (⌘K or Ctrl+K) inside the "Save Bookmark" button and an aria-label to the URL input.
🎯 Why: Makes the application more intuitive by exposing keyboard shortcuts to power users, while avoiding SSR hydration mismatch issues.
📸 Before/After: Visual hints added inside the button.
♿ Accessibility: The keyboard hints are wrapped in semantic `<kbd>` elements, and the bookmark input now has an explicit `aria-label="Bookmark URL"`.

---
*PR created automatically by Jules for task [5473460377444606773](https://jules.google.com/task/5473460377444606773) started by @pffreitas*