### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in web scraping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,18 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2025-10-25 - SSRF Protection in Web Scraping
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) as `isValidUrl` only checked for http/https protocols, allowing requests to internal and private network addresses (like `localhost` or `169.254.169.254`).
+**Learning:** Using `new URL()` automatically normalizes some IP representations, but raw IPv6 addresses must be properly bracketed. `isValidUrl` must explicitly block private and internal IP ranges to ensure security in operations fetching remote resources.
+**Prevention:** Implement strict SSRF blocklists referencing `urlObj.hostname`, verifying that internal, private (IPv4/IPv6), and loopback addresses are explicitly denied access.
+
+## 2025-10-25 - Advanced SSRF Bypasses in Web Scraping
+**Vulnerability:** The initial SSRF mitigation failed to protect against loopback bypasses using alternate subnet representations (e.g., `127.0.0.2` instead of strictly `127.0.0.1`) and 'any' IP representations like `0.0.0.0`. Additionally, a regex attempting to fix unbracketed IPv6 broke credentials parsing in URLs.
+**Learning:** Checking strictly for `"127.0.0.1"` is insufficient for SSRF protection because the entire `127.0.0.0/8` subnet routs back to loopback. Furthermore, `0.0.0.0` translates to `127.0.0.1` on Linux/macOS systems. When manipulating URLs to handle edge cases like IPv6 parsing, one must ensure regexes handle the full spectrum of valid URIs (like authentication elements).
+**Prevention:** Always block the full 127.x.x.x subnet using regex `/^127\.\d+\.\d+\.\d+$/` and explicitely block `0.0.0.0`. When implementing fallback URL parsing hacks (like bracketing unbracketed IPv6), wrap them in try-catch to attempt native `URL()` parsing first, only applying manual regex intervention if the native parse fails.
+
+## 2025-10-25 - Regex Edge Cases in SSRF Prevention
+**Vulnerability:** Initial SSRF mitigation blocked legitimate public domains that started with private IPv4 octets (e.g., `10.example.com` or `192.168.com`) due to overly broad regexes that only checked the prefix (e.g., `/^10\./`).
+**Learning:** `new URL()` automatically strips port information from the `hostname` property and parses IPs nicely, but if regex matching is used to check for private IPs on the `hostname`, the pattern must strictly match the start and end of the string. Additionally, Node.js automatically normalizes IPv4-mapped IPv6 representations like `[::ffff:127.0.0.1]` into their hex equivalents like `[::ffff:7f00:1]`.
+**Prevention:** When validating IP boundaries with regexes, explicitly define the IP string structure using full dotted-decimal notations bounded by start (`^`) and end (`$`) string anchors (e.g., `/^10\.\d+\.\d+\.\d+$/`). Always test IP validation logic against valid domain names with numeric prefixes to check for false positives, and verify exactly how the language runtime normalizes obscure IP formats.

--- a/packages/shared/src/__tests__/services/web-scraping.service.test.ts
+++ b/packages/shared/src/__tests__/services/web-scraping.service.test.ts
@@ -29,6 +29,34 @@ describe("WebScrapingService", () => {
     );
   });
 
+  describe("isValidUrl", () => {
+    it("should return true for valid public URLs", () => {
+      expect(webScrapingService.isValidUrl("http://google.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("https://example.com/path?foo=bar")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://user:pass@example.com:8080/")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://10.example.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://192.168.com")).toBe(true);
+    });
+
+    it("should return false for SSRF targets (localhost, private IPs)", () => {
+      expect(webScrapingService.isValidUrl("http://localhost")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://127.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://127.0.0.2")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://0.0.0.0")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://2130706433/")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://0x7f000001")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://10.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://192.168.1.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://172.16.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://169.254.169.254")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://::1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::1]")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::]")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::ffff:127.0.0.1]")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[fe80::1]")).toBe(false);
+    });
+  });
+
   describe("scrape", () => {
     it("should route twitter URLs to TwitterService", async () => {
       mockTwitterService.isTwitterUrl.mockReturnValue(true);

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -39,8 +39,38 @@ export class WebScrapingServiceImpl implements WebScrapingService {
 
   isValidUrl(url: string): boolean {
     try {
-      const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      let urlToParse = url;
+      try {
+        new URL(url);
+      } catch {
+        // Handle unbracketed IPv6 if initial parse fails
+        const match = url.match(/^(https?:\/\/(?:[^@\/]+@)?)([^\[\]\/:]+(?::[^\[\]\/:]+){2,})((?::\d+)?(?:[\/\?#].*)?)$/i);
+        if (match) {
+          urlToParse = `${match[1]}[${match[2]}]${match[3]}`;
+        }
+      }
+
+      const urlObj = new URL(urlToParse);
+
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      // 🛡️ Sentinel: SSRF prevention - Block internal/private network access
+      const hostname = urlObj.hostname;
+
+      const isLocalhost = hostname === "localhost" || /^127\.\d+\.\d+\.\d+$/.test(hostname) || hostname === "[::1]" || hostname === "[::]" || /^\[::ffff:7f00:1\]$/i.test(hostname) || hostname === "0.0.0.0";
+      const isPrivateIPv4 = /^10\.\d+\.\d+\.\d+$/.test(hostname) ||
+                            /^192\.168\.\d+\.\d+$/.test(hostname) ||
+                            /^172\.(1[6-9]|2[0-9]|3[0-1])\.\d+\.\d+$/.test(hostname) ||
+                            /^169\.254\.\d+\.\d+$/.test(hostname);
+      const isPrivateIPv6 = /^\[(fc|fd|fe80)/i.test(hostname);
+
+      if (isLocalhost || isPrivateIPv4 || isPrivateIPv6) {
+        return false;
+      }
+
+      return true;
     } catch {
       return false;
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `isValidUrl` method in the `WebScrapingServiceImpl` previously only validated that the URL protocol was HTTP/HTTPS. This permitted Server-Side Request Forgery (SSRF) attacks, allowing malicious actors to supply URLs pointing to internal or private networks (e.g., `http://localhost`, `http://169.254.169.254`, or AWS metadata endpoints).
🎯 Impact: Attackers could abuse the bookmark scraping or preview endpoints to perform internal port scanning, access internal services, or retrieve sensitive cloud metadata credentials.
🔧 Fix: Implemented strict synchronous blocklists against resolved hostnames utilizing Node's native `new URL` normalizations. Added block rules targeting loopback (`127.x.x.x`, `0.0.0.0`, `[::]`, `[::1]`) and private IPv4/IPv6 address spaces. Added safe unbracketed IPv6 fallback handling. Added strict bounds to regex checking to prevent false positives on subdomains.
✅ Verification: Ran testing suite successfully including robust regression test assertions spanning several known bypass methodologies.

---
*PR created automatically by Jules for task [14434346468409612492](https://jules.google.com/task/14434346468409612492) started by @pffreitas*