### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in web scraper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-06-21 - Unrestricted URL Parsing leading to SSRF
+**Vulnerability:** The web scraper service parsed user-supplied URLs without restricting requests to internal IP ranges, creating a high-risk SSRF (Server-Side Request Forgery) vulnerability.
+**Learning:** Node.js `new URL(url).hostname` automatically normalizes alternative IP representations (like parsing `http://2130706433/` to `127.0.0.1`), making it a reliable mechanism for implementing SSRF blocklists against internal network addresses without complex regex for bypasses.
+**Prevention:** Always validate and block local loopbacks, AWS metadata IPs, and private IP ranges (`10.x.x.x`, `172.16.x.x`, `192.168.x.x`) immediately after parsing the URL in any service that fetches external resources on behalf of a user.

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,7 +40,34 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      // 🛡️ Sentinel: Prevent Server-Side Request Forgery (SSRF) by blocking internal network addresses and private IP ranges
+      const hostname = urlObj.hostname;
+
+      const internalHosts = ["localhost", "127.0.0.1", "0.0.0.0", "[::1]", "169.254.169.254"];
+      if (internalHosts.includes(hostname)) {
+        return false;
+      }
+
+      if (hostname.endsWith(".local") || hostname.endsWith(".internal")) {
+        return false;
+      }
+
+      const ipRegex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+      const match = hostname.match(ipRegex);
+      if (match) {
+        const p1 = parseInt(match[1], 10);
+        const p2 = parseInt(match[2], 10);
+        if (p1 === 127) return false; // Loopback range 127.0.0.0/8
+        if (p1 === 10) return false;
+        if (p1 === 172 && p2 >= 16 && p2 <= 31) return false;
+        if (p1 === 192 && p2 === 168) return false;
+      }
+
+      return true;
     } catch {
       return false;
     }

--- a/test-web-scraping.js
+++ b/test-web-scraping.js
@@ -1,0 +1,9 @@
+const { WebScrapingServiceImpl } = require("./packages/shared/dist/services/web-scraping.service");
+const { CosmicHttpClient } = require("./packages/shared/dist/services/http-client");
+
+const scraper = new WebScrapingServiceImpl(new CosmicHttpClient());
+
+console.log("127.0.0.1:", scraper.isValidUrl("http://127.0.0.1"));
+console.log("2130706433:", scraper.isValidUrl("http://2130706433"));
+console.log("localhost:", scraper.isValidUrl("http://localhost"));
+console.log("google.com:", scraper.isValidUrl("http://google.com"));


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The web scraper service parsed user-supplied URLs and fetched them via HTTP GET without restricting the requests to internal IP ranges. This created a high-risk SSRF (Server-Side Request Forgery) vulnerability.
🎯 **Impact:** An attacker could craft malicious bookmarks to port scan the internal network, interact with internal services on loopback (`127.0.0.1`), or access sensitive AWS instance metadata at `169.254.169.254`.
🔧 **Fix:** Added a robust IP range blocklist inside `isValidUrl` to explicitly block loopback addresses, AWS metadata IPs, and private subnets (`10.x.x.x`, `172.16.x.x`, `192.168.x.x`). We rely on the Node.js `URL` parser's auto-normalization properties to defend against octal/hex IP bypasses (e.g. `http://0177.0.0.1/` parsing to `127.0.0.1`).
✅ **Verification:** Web scraper unit tests were executed and passed. Manual tests with bypassing formats (`2130706433`, `[::1]`) show requests correctly fail validation.

---
*PR created automatically by Jules for task [2628928148330754232](https://jules.google.com/task/2628928148330754232) started by @pffreitas*