### PR TITLE
🎨 Palette: Add cross-platform keyboard shortcut hint to save bookmark button

### DIFF
--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -19,6 +19,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
@@ -76,8 +77,10 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -143,7 +146,17 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         }}
       >
         <Bookmark size={16} />
-        Save Bookmark
+        <span>Save Bookmark</span>
+        {isMac !== null && (
+          <span className="flex items-center gap-0.5 text-xs text-white/70 ml-1 hidden sm:flex">
+            <kbd className="font-sans px-1.5 py-0.5 rounded-md border border-white/20 bg-white/10">
+              {isMac ? "⌘" : "Ctrl"}
+            </kbd>
+            <kbd className="font-sans px-1.5 py-0.5 rounded-md border border-white/20 bg-white/10">
+              K
+            </kbd>
+          </span>
+        )}
       </button>
     </>
   );


### PR DESCRIPTION
💡 **What:** Added a visible cross-platform keyboard shortcut hint (`⌘ K` or `Ctrl K`) to the "Save Bookmark" button and updated the keydown listener to support both OS environments without breaking SSR hydration.
🎯 **Why:** To make the application more discoverable and power-user friendly. Previous logic assumed `metaKey` (Mac only) and was hidden from the UI.
📸 **Before/After:** The button now elegantly shows a badge `⌘ K` on Macs and `Ctrl K` on non-Macs for screens `sm` and above.
♿ **Accessibility:** Wrapped the shortcut keys in semantic `<kbd>` tags and handled `useEffect` initialization to prevent disruptive screen reader hydration mismatches.

---
*PR created automatically by Jules for task [11938734331666509612](https://jules.google.com/task/11938734331666509612) started by @pffreitas*