### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) vulnerability in web scraper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-19 - SSRF Vulnerability in URL validation
+**Vulnerability:** Server-Side Request Forgery (SSRF) allowed internal network access because `WebScrapingServiceImpl.isValidUrl` only checked if the URL protocol was HTTP/HTTPS.
+**Learning:** `new URL(url).hostname` automatically parses decimal IP representations (like `http://2130706433/` -> `127.0.0.1`), making it reliable for blocking malicious network access. Additionally, wrapping `new URL()` in a `try/catch` serves as a safe default by automatically throwing `ERR_INVALID_URL` for unbracketed raw IPv6 addresses.
+**Prevention:** Always validate hostnames against a blocklist of internal networks (localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, etc) before fetching data. Rely on `new URL().hostname` for accurate IP normalisation instead of raw string parsing.

--- a/packages/shared/src/__tests__/services/web-scraping.service.test.ts
+++ b/packages/shared/src/__tests__/services/web-scraping.service.test.ts
@@ -29,6 +29,30 @@ describe("WebScrapingService", () => {
     );
   });
 
+  describe("isValidUrl (SSRF Protection)", () => {
+    it("should accept valid external URLs", () => {
+      expect(webScrapingService.isValidUrl("https://example.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://google.com")).toBe(true);
+    });
+
+    it("should reject invalid protocols", () => {
+      expect(webScrapingService.isValidUrl("file:///etc/passwd")).toBe(false);
+      expect(webScrapingService.isValidUrl("ftp://example.com")).toBe(false);
+    });
+
+    it("should reject internal IP addresses and localhost (SSRF)", () => {
+      expect(webScrapingService.isValidUrl("http://localhost:3000")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://127.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::1]")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://169.254.169.254")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://10.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://192.168.1.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://172.16.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://0.0.0.0")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://2130706433")).toBe(false); // 127.0.0.1 in decimal
+    });
+  });
+
   describe("scrape", () => {
     it("should route twitter URLs to TwitterService", async () => {
       mockTwitterService.isTwitterUrl.mockReturnValue(true);

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,8 +40,28 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+
+      // 🛡️ Sentinel: Restrict SSRF by blocking internal networks and localhost
+      const isHttp = urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (!isHttp) return false;
+
+      const hostname = urlObj.hostname;
+
+      const isBlocked = [
+        /^localhost$/i,
+        /^127(\.\d+){3}$/,
+        /^\[::1\]$/,
+        /^::1$/,
+        /^169\.254(\.\d+){2}$/,
+        /^10(\.\d+){3}$/,
+        /^172\.(1[6-9]|2[0-9]|3[0-1])(\.\d+){2}$/,
+        /^192\.168(\.\d+){2}$/,
+        /^0\.0\.0\.0$/,
+      ].some(pattern => pattern.test(hostname));
+
+      return !isBlocked;
     } catch {
+      // 🛡️ Sentinel: Safe default - reject unparseable URLs (e.g. unbracketed IPv6)
       return false;
     }
   }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) allowed internal network access via web scraping endpoint
🎯 Impact: Attackers could scan and access internal network resources on AWS, loopback interfaces and internal application services
🔧 Fix: Added blocklist to `WebScrapingServiceImpl.isValidUrl` validating `URL.hostname` against localhost, RFC 1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), Link-local, and loopback ranges. Rely on `URL.hostname`'s built-in normalisation of alternatives like `0177.0.0.1` and `2130706433`.
✅ Verification: Ran `cd packages/shared && bun install && bun test` and SSRF test suite passed.

---
*PR created automatically by Jules for task [9754014653714766127](https://jules.google.com/task/9754014653714766127) started by @pffreitas*