### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in WebScrapingService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-31 - WebScrapingService SSRF Vulnerability
+**Vulnerability:** The `isValidUrl` method in `WebScrapingService` allowed HTTP and HTTPS protocols but did not block internal, local, or metadata IP addresses, enabling Server-Side Request Forgery (SSRF) against internal resources.
+**Learning:** Checking the protocol alone is insufficient for secure URL validation. Hostnames and IPs must be actively evaluated against internal network ranges (like `localhost`, `127.0.0.0/8`, `10.0.0.0/8`, `169.254.169.254`, etc.) before making outbound requests. Utilizing `new URL(url).hostname` acts as a valuable defense-in-depth measure because it handles alternative IP representations (e.g., integer parsing) automatically prior to our regex matchers.
+**Prevention:** Always implement an internal network blocklist for outbound requests, relying on parsed `.hostname` rather than raw URL strings to catch obfuscated/normalized payloads safely.

--- a/packages/shared/src/__tests__/services/web-scraping.service.test.ts
+++ b/packages/shared/src/__tests__/services/web-scraping.service.test.ts
@@ -29,6 +29,28 @@ describe("WebScrapingService", () => {
     );
   });
 
+  describe("isValidUrl", () => {
+    it("should allow external http and https URLs", () => {
+      expect(webScrapingService.isValidUrl("https://example.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://example.com")).toBe(true);
+    });
+
+    it("should reject non-http/https protocols", () => {
+      expect(webScrapingService.isValidUrl("ftp://example.com")).toBe(false);
+      expect(webScrapingService.isValidUrl("file:///etc/passwd")).toBe(false);
+    });
+
+    it("should reject internal network hostnames and IPs (SSRF)", () => {
+      expect(webScrapingService.isValidUrl("http://localhost")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://127.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://2130706433/")).toBe(false); // 127.0.0.1 integer parsing
+      expect(webScrapingService.isValidUrl("http://10.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://192.168.1.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://169.254.169.254/latest/meta-data")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::1]/")).toBe(false);
+    });
+  });
+
   describe("scrape", () => {
     it("should route twitter URLs to TwitterService", async () => {
       mockTwitterService.isTwitterUrl.mockReturnValue(true);

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,7 +40,35 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      const hostname = urlObj.hostname;
+
+      // 🛡️ Sentinel: Restrict SSRF by rejecting internal/private IP addresses and hostnames
+      if (
+        hostname === "localhost" ||
+        hostname === "0.0.0.0" ||
+        /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/.test(hostname) ||
+        /^10(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/.test(hostname) ||
+        /^172\.(?:1[6-9]|2[0-9]|3[0-1])(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){2}$/.test(hostname) ||
+        /^192\.168(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){2}$/.test(hostname) ||
+        hostname === "169.254.169.254" ||
+        (hostname.includes(":") && (
+          hostname === "[::1]" ||
+          hostname.startsWith("[fc") ||
+          hostname.startsWith("[fd") ||
+          hostname.startsWith("[fe8") ||
+          hostname.startsWith("[fe9") ||
+          hostname.startsWith("[fea") ||
+          hostname.startsWith("[feb")
+        ))
+      ) {
+        return false;
+      }
+
+      return true;
     } catch {
       return false;
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `WebScrapingService` was relying solely on `http:`/`https:` protocol checks in `isValidUrl` without validating the host. This meant it would willingly fetch internal IP addresses (like `127.0.0.1`, `localhost`, AWS metadata APIs like `169.254.169.254`, etc.) if passed as input, leading to a Server-Side Request Forgery (SSRF) vulnerability.
🎯 **Impact:** Malicious actors could use the scraping functionality to scan internal networks, access private infrastructure metadata, or bypass local firewalls.
🔧 **Fix:** 
- Updated `isValidUrl` to actively block private and internal IP ranges by explicitly parsing the input via `new URL(url).hostname`.
- Leveraging `new URL().hostname` provides defense-in-depth against obfuscated URLs (such as integer representations of IPs like `http://2130706433/` for `127.0.0.1` or bracketed IPv6 syntax like `[::1]`).
- Appended a journal entry for Sentinel highlighting the danger of skipping hostname validations.
- Included comprehensive test coverage.
✅ **Verification:** Verify by running unit tests `bun test src/__tests__/services/web-scraping.service.test.ts`.

---
*PR created automatically by Jules for task [16600737490417599273](https://jules.google.com/task/16600737490417599273) started by @pffreitas*