### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to mobile add button

### DIFF
--- a/apps/web/components/mobile/bottom-nav.tsx
+++ b/apps/web/components/mobile/bottom-nav.tsx
@@ -63,12 +63,13 @@ export function BottomNavigation() {
               <button
                 key={item.label}
                 onClick={handleAddClick}
+                aria-label="Add new bookmark"
                 className="flex flex-col items-center justify-center py-2 px-3 min-w-0 flex-1"
               >
                 <div
                   className={cn(
                     "flex items-center justify-center w-6 h-6 mb-1",
-                    "text-gray-600"
+                    "text-gray-600",
                   )}
                 >
                   {item.icon}
@@ -89,7 +90,7 @@ export function BottomNavigation() {
               <div
                 className={cn(
                   "flex items-center justify-center w-4 h-4 mb-1",
-                  isActive ? "text-blue-600" : "text-gray-600"
+                  isActive ? "text-blue-600" : "text-gray-600",
                 )}
               >
                 {item.icon}
@@ -97,7 +98,7 @@ export function BottomNavigation() {
               <span
                 className={cn(
                   "text-xs font-medium",
-                  isActive ? "text-blue-600" : "text-gray-600"
+                  isActive ? "text-blue-600" : "text-gray-600",
                 )}
               >
                 {item.label}


### PR DESCRIPTION
## 💡 What
Added an `aria-label="Add new bookmark"` to the icon-only "Add" button in the mobile `BottomNavigation` component.

## 🎯 Why
Icon-only buttons without an explicit accessible name are confusing or silent for screen reader users. The "Add" button triggers the new bookmark modal, and explicitly labeling it ensures users navigating with assistive technologies understand the action before interacting with it.

## 📸 Before/After
Visually, the UI remains exactly the same. The change only affects the HTML DOM tree and accessibility tree.

## ♿ Accessibility
Improves keyboard and screen reader accessibility by ensuring the main call-to-action button in the mobile bottom navigation bar has a descriptive accessible name.

---
*PR created automatically by Jules for task [3641475541001452426](https://jules.google.com/task/3641475541001452426) started by @pffreitas*