### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in URL validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-25 - SSRF Protection via URL Normalization
+**Vulnerability:** The `isValidUrl` method only checked for `http:` and `https:` protocols, leaving the scraping and preview endpoints vulnerable to Server-Side Request Forgery (SSRF) attacks against internal networks (e.g., `localhost`, `169.254.169.254`).
+**Learning:** Using `new URL(url).hostname` automatically normalizes alternative IP representations (e.g., parsing `http://2130706433/` to `127.0.0.1`), making it a reliable mechanism for implementing SSRF blocklists against internal network addresses without needing complex custom IP normalization logic.
+**Prevention:** Always validate user-provided URLs against a strict blocklist of internal IP ranges and hostnames using the parsed and normalized `.hostname` property of the `URL` object.

--- a/packages/shared/src/__tests__/services/web-scraping.service.test.ts
+++ b/packages/shared/src/__tests__/services/web-scraping.service.test.ts
@@ -58,4 +58,28 @@ describe("WebScrapingService", () => {
       expect(result.title).toBe("Regular Page");
     });
   });
+
+  describe("isValidUrl", () => {
+    it("should return true for valid external URLs", () => {
+      expect(webScrapingService.isValidUrl("https://example.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://google.com")).toBe(true);
+    });
+
+    it("should return false for invalid protocols", () => {
+      expect(webScrapingService.isValidUrl("ftp://example.com")).toBe(false);
+      expect(webScrapingService.isValidUrl("file:///etc/passwd")).toBe(false);
+    });
+
+    it("should block internal hostnames and IPs (SSRF protection)", () => {
+      expect(webScrapingService.isValidUrl("http://localhost")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://127.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::1]")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://0.0.0.0")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://169.254.169.254/latest/meta-data")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://10.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://192.168.1.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://172.16.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://2130706433/")).toBe(false); // 127.0.0.1 normalized
+    });
+  });
 });

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,7 +40,26 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      // 🛡️ Sentinel: Block internal and local network requests to prevent Server-Side Request Forgery (SSRF)
+      const hostname = urlObj.hostname;
+      if (
+        hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "[::1]" ||
+        hostname === "0.0.0.0" ||
+        hostname.startsWith("169.254.") ||
+        hostname.startsWith("10.") ||
+        hostname.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\./) ||
+        hostname.startsWith("192.168.")
+      ) {
+        return false;
+      }
+
+      return true;
     } catch {
       return false;
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `isValidUrl` method used by the web scraping and preview endpoints only checked for the presence of `http:` and `https:` protocols. This allowed attackers to submit internal IP addresses (e.g., `127.0.0.1`, `169.254.169.254`) and hostnames (e.g., `localhost`) to the scraping endpoints, resulting in Server-Side Request Forgery (SSRF) vulnerabilities where the backend server would make requests to internal networks.
🎯 Impact: Attackers could probe internal network services, access internal metadata APIs (such as AWS instance metadata), and potentially extract sensitive data or compromise internal services not meant to be publicly exposed.
🔧 Fix:
- Updated `packages/shared/src/services/web-scraping.service.ts` to implement a strict IP and hostname blocklist in `isValidUrl()`.
- Utilized the `hostname` property from the built-in `URL` object which automatically normalizes IP addresses (e.g., it converts raw integer IPs like `2130706433` into `127.0.0.1`), providing robust protection against basic IP obfuscation techniques.
- Prevented requests to `localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`, and common private IPv4 blocks (`10.x.x.x`, `172.16.x.x`, `192.168.x.x`, and `169.254.x.x`).
- Added robust unit tests verifying the protection mechanisms.
✅ Verification: Ensure tests pass via `cd packages/shared && bun test src/__tests__/services/web-scraping.service.test.ts`. Attempts to pass internal URLs to the web scraping/preview endpoints will now be rejected.

---
*PR created automatically by Jules for task [15581616755582201227](https://jules.google.com/task/15581616755582201227) started by @pffreitas*