### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcut hint tooltip to Save Bookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2026-05-21 - Keyboard Shortcut Hints with Tooltips
+**Learning:** For floating or persistent primary actions that have global keyboard shortcuts (like "Save Bookmark" triggered by `Cmd/Ctrl+K`), providing a tooltip explicitly detailing the shortcut significantly improves discoverability without cluttering the UI. Users often miss global shortcuts unless visually hinted contextually near the action button.
+**Action:** Always provide tooltip hints for primary actions that support keyboard shortcuts. Wrap the button in a `TooltipProvider` and conditionally display the `isMac` specific shortcut key using semantic `<kbd>` tags.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -19,13 +25,14 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
-    (state) => state.bookmarks.createLoading
+    (state) => state.bookmarks.createLoading,
   );
   const previewLoading = useAppSelector(
-    (state) => state.bookmarks.previewLoading
+    (state) => state.bookmarks.previewLoading,
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
@@ -41,9 +48,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
       const preview = result.payload as PreviewResponse;
 
       if (preview.scrapable) {
-        const createResult = await dispatch(
-          createBookmark({ sourceUrl: url })
-        );
+        const createResult = await dispatch(createBookmark({ sourceUrl: url }));
         if (createBookmark.fulfilled.match(createResult)) {
           setShowOverlay(false);
           setUrl("");
@@ -76,8 +81,10 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +142,38 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent
+              side="bottom"
+              className="flex items-center gap-1.5 px-2.5 py-1.5"
+            >
+              <span>Save Bookmark</span>
+              <span className="flex items-center gap-0.5 text-muted-foreground">
+                <kbd className="font-sans px-1.5 py-0.5 rounded border border-primary/20 bg-primary/10 text-[10px] leading-none">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1.5 py-0.5 rounded border border-primary/20 bg-primary/10 text-[10px] leading-none">
+                  K
+                </kbd>
+              </span>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }


### PR DESCRIPTION
💡 What: Added a tooltip hint to the `Save Bookmark` button that explicitly displays the global keyboard shortcut (`Cmd+K` or `Ctrl+K`) for saving bookmarks.

🎯 Why: The "Save Bookmark" shortcut was previously a hidden global hotkey. Providing a tooltip explicitly detailing the shortcut significantly improves discoverability without cluttering the UI. Users often miss global shortcuts unless visually hinted contextually near the action button.

📸 Before/After: Before, the button was just plain text. Now, hovering the button displays the "Save Bookmark" text along with a stylized shortcut pill showing the correct OS-specific keys.

♿ Accessibility: Wrapped the shortcut keys in semantic `<kbd>` elements to enhance both visual distinctiveness and screen reader accessibility. Added focus-visible styles to the button to improve keyboard navigation. Fixed the shortcut listener to respect both `metaKey` (Mac) and `ctrlKey` (Windows) accurately, while safely detecting OS post-hydration.

---
*PR created automatically by Jules for task [7725371852465370983](https://jules.google.com/task/7725371852465370983) started by @pffreitas*