### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in web-scraping service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-24 - Unrestricted Web Scraper SSRF Vulnerability
+**Vulnerability:** The bookmark preview endpoint and web scraper accepted any valid HTTP/HTTPS URL, including internal IP addresses and `localhost`, leading to Server-Side Request Forgery (SSRF) risks.
+**Learning:** In Node.js, `new URL(url).hostname` automatically normalizes alternative IP representations (e.g., parsing `http://2130706433/` to `127.0.0.1`), making it a reliable mechanism for implementing SSRF blocklists against internal network addresses.
+**Prevention:** Always validate user-provided URLs against an explicit blocklist of private/internal network patterns (e.g., `127.0.0.1`, `10.*`, `169.254.*`, `localhost`) before passing them to server-side HTTP clients.

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,7 +40,29 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      // 🛡️ Sentinel: Block SSRF attempts to internal networks
+      const hostname = urlObj.hostname;
+      if (
+        hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "0.0.0.0" ||
+        hostname === "[::1]" ||
+        hostname === "[::]" ||
+        hostname.startsWith("10.") ||
+        hostname.startsWith("192.168.") ||
+        hostname.startsWith("169.254.") ||
+        hostname.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\./) !== null ||
+        hostname.endsWith(".internal") ||
+        hostname.endsWith(".local")
+      ) {
+        return false;
+      }
+
+      return true;
     } catch {
       return false;
     }


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: Web scraper accepted internal IP addresses and `localhost`, leading to SSRF risks.
* 🎯 Impact: An attacker could perform network scanning and access metadata services.
* 🔧 Fix: Implemented an IP blocklist inside the URL validation process using the URL object's hostname properties. It blocks `localhost`, `127.0.0.1`, `0.0.0.0`, `[::]`, `[::1]`, and internal network IP ranges.
* ✅ Verification: Tested using unit tests and verified via manually testing against example IPs.

---
*PR created automatically by Jules for task [14081165939110125313](https://jules.google.com/task/14081165939110125313) started by @pffreitas*