### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in web scraper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-11-20 - SSRF Vulnerability in Web Scraping
+**Vulnerability:** The `isValidUrl` method only checked for HTTP/HTTPS protocols, allowing attackers to provide internal IP addresses (e.g., `localhost`, `127.0.0.1`, `169.254.169.254`) that would be fetched by the server, leading to Server-Side Request Forgery (SSRF).
+**Learning:** Using `new URL(url).hostname` automatically normalizes alternative IP representations (e.g., parsing integer IPs like `2130706433` to `127.0.0.1`), making it a reliable mechanism to check against a blocklist of internal network addresses. Furthermore, when using `startsWith` for blocklisting (like `10.`), it's critical to first ensure the hostname is strictly an IP address to avoid blocking legitimate domains like `10.example.com`.
+**Prevention:** Always validate and block internal network ranges, loopback addresses, and metadata server IPs before fetching user-provided URLs. Use strict regex or IP format validation before applying substring checks.

--- a/packages/shared/src/__tests__/services/web-scraping.service.test.ts
+++ b/packages/shared/src/__tests__/services/web-scraping.service.test.ts
@@ -29,6 +29,23 @@ describe("WebScrapingService", () => {
     );
   });
 
+  describe("isValidUrl", () => {
+    it("should allow public URLs", () => {
+      expect(webScrapingService.isValidUrl("https://example.com")).toBe(true);
+      expect(webScrapingService.isValidUrl("http://10.example.com")).toBe(true);
+    });
+
+    it("should block internal network and loopback addresses (SSRF protection)", () => {
+      expect(webScrapingService.isValidUrl("http://localhost")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://127.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://10.0.0.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://192.168.1.1")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://169.254.169.254")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://[::1]")).toBe(false);
+      expect(webScrapingService.isValidUrl("http://2130706433")).toBe(false); // 127.0.0.1 as integer
+    });
+  });
+
   describe("scrape", () => {
     it("should route twitter URLs to TwitterService", async () => {
       mockTwitterService.isTwitterUrl.mockReturnValue(true);

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -40,7 +40,38 @@ export class WebScrapingServiceImpl implements WebScrapingService {
   isValidUrl(url: string): boolean {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+
+      // 🛡️ Sentinel: SSRF protection blocking internal network and loopback addresses
+      const hostname = urlObj.hostname;
+
+      if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+        return false;
+      }
+
+      const isIPv4 = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(hostname);
+      const isIPv6 = /^\[.*\]$/.test(hostname);
+
+      if (isIPv4 || isIPv6) {
+        const ip = hostname.replace(/^\[|\]$/g, "");
+        if (
+          ip.startsWith("127.") ||
+          ip === "0.0.0.0" ||
+          ip === "::1" ||
+          ip.startsWith("10.") ||
+          ip.startsWith("192.168.") ||
+          ip === "169.254.169.254" ||
+          /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip) ||
+          /^fc00:/i.test(ip) ||
+          /^fe80:/i.test(ip)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
     } catch {
       return false;
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `isValidUrl` method in the web scraping service only checked for HTTP/HTTPS protocols. Attackers could submit URLs pointing to internal network IP addresses (like `127.0.0.1`, `localhost`, `169.254.169.254`, etc.) resulting in the server sending requests to local services or internal metadata servers.
🎯 **Impact:** Allowed Server-Side Request Forgery (SSRF) whereby an attacker could probe internal networks, read local services, or access cloud metadata endpoints.
🔧 **Fix:** Updated `isValidUrl` to parse the hostname using `new URL()` and explicitly block `localhost`, `.localhost` domains, IPv4 ranges starting with `10.`, `127.`, `192.168.`, AWS metadata endpoint `169.254.169.254`, and equivalent IPv6 local/link-local addresses (e.g. `::1`). Evaluated against both literal representations and integer representations of IP addresses. Note: This handles literal string/IP representations; full DNS-based SSRF mitigation requires deeper network layer filtering.
✅ **Verification:** Added comprehensive unit tests in `packages/shared/src/__tests__/services/web-scraping.service.test.ts` to ensure `isValidUrl` blocks malicious inputs while allowing legitimate domains like `example.com` and `10.example.com`. Tests pass successfully. Updated Sentinel journal with learnings.

---
*PR created automatically by Jules for task [10662821721302893406](https://jules.google.com/task/10662821721302893406) started by @pffreitas*