### PR TITLE
🎨 Palette: [UX improvement] Add cross-platform keyboard shortcut hint and support for Save Bookmark

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2024-05-18 - Cross-Platform Keyboard Shortcut Accessibility
+**Learning:** When implementing global keyboard shortcuts in React components, relying solely on `event.metaKey` excludes Windows and Linux users, reducing accessibility.
+**Action:** Always check for `(event.metaKey || event.ctrlKey)` to guarantee cross-platform functionality.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -19,13 +25,18 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
-    (state) => state.bookmarks.createLoading
+    (state) => state.bookmarks.createLoading,
   );
   const previewLoading = useAppSelector(
-    (state) => state.bookmarks.previewLoading
+    (state) => state.bookmarks.previewLoading,
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
@@ -41,9 +52,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
       const preview = result.payload as PreviewResponse;
 
       if (preview.scrapable) {
-        const createResult = await dispatch(
-          createBookmark({ sourceUrl: url })
-        );
+        const createResult = await dispatch(createBookmark({ sourceUrl: url }));
         if (createBookmark.fulfilled.match(createResult)) {
           setShowOverlay(false);
           setUrl("");
@@ -77,7 +86,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +144,35 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent side="bottom" sideOffset={8}>
+              <p className="flex items-center gap-1 text-xs">
+                Save Bookmark
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 text-gray-900 border-gray-200">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 text-gray-900 border-gray-200">
+                  K
+                </kbd>
+              </p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/web_server.log
+++ b/web_server.log
@@ -1,0 +1,18 @@
+• turbo 2.7.5
+• Packages in scope: @cosmic-dolphin/web
+• Running dev in 1 packages
+• Remote caching disabled
+@cosmic-dolphin/api-client:build: cache hit, replaying logs b824aa6e02750861
+@cosmic-dolphin/api-client:build: $ tsc && tsc -p tsconfig.esm.json
+@cosmic-dolphin/web:dev: cache bypass, force executing ad20cc6bd8e1cc7d
+@cosmic-dolphin/web:dev: $ next dev --port 3001
+@cosmic-dolphin/web:dev: ▲ Next.js 16.1.6 (Turbopack)
+@cosmic-dolphin/web:dev: - Local:         http://localhost:3001
+@cosmic-dolphin/web:dev: - Network:       http://192.168.0.2:3001
+@cosmic-dolphin/web:dev:
+@cosmic-dolphin/web:dev: ✓ Starting...
+@cosmic-dolphin/web:dev: ⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+@cosmic-dolphin/web:dev: ✓ Ready in 1483ms
+@cosmic-dolphin/web:dev: ○ Compiling / ...
+@cosmic-dolphin/web:dev:  GET / 200 in 7.5s (compile: 6.7s, proxy.ts: 141ms, render: 651ms)
+@cosmic-dolphin/web:dev:  GET /test-component 200 in 2.1s (compile: 1598ms, proxy.ts: 36ms, render: 468ms)


### PR DESCRIPTION
💡 What: Added a tooltip hint dynamically rendering "⌘ K" or "Ctrl K" (depending on the OS) to the "Save Bookmark" button, and extended the keyboard event listener to handle `ctrlKey` alongside `metaKey`.
🎯 Why: Relying solely on `event.metaKey` excluded Windows and Linux users from utilizing the shortcut. The tooltip surfaces this invisible functionality directly in the UI context to improve discoverability.
📸 Before/After: Before, the button had no tooltip and the shortcut was Mac-only. After, hovering reveals a semantic shortcut hint, and the feature works cross-platform.
♿ Accessibility: Increased cross-platform accessibility, wrapped keyboard hints in semantic `<kbd>` tags for screen readers, and ensured safe OS detection via `useEffect` to prevent SSR mismatches.

---
*PR created automatically by Jules for task [5017298364128552943](https://jules.google.com/task/5017298364128552943) started by @pffreitas*