### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in web scraper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-25 - DNS-based SSRF Bypasses String Matching
+**Vulnerability:** The web scraper superficially checked URL validity without verifying the resolved IP address, allowing an attacker to request internal network resources via Server-Side Request Forgery (SSRF) using domains that resolve to private IPs (e.g., `localtest.me`).
+**Learning:** Relying solely on static string or Regex checks against `new URL(url).hostname` is vulnerable to DNS-based bypasses. An attacker can use custom domains that resolve to `127.0.0.1` or internal ranges.
+**Prevention:** Comprehensive prevention requires resolving the hostname to an IP address prior to the request and validating it against private/internal IP blocks, or using network-level egress controls.

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,4 +1,18 @@
 const got = require("got").default || require("got");
+import { promises as dns } from "dns";
+import * as net from "net";
+
+function isPrivateIp(ip: string): boolean {
+  if (!net.isIP(ip)) return false;
+  if (ip === "127.0.0.1" || ip === "::1" || ip.startsWith("::ffff:127.")) return true;
+  if (ip.startsWith("10.")) return true;
+  if (ip.startsWith("192.168.")) return true;
+  if (ip.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\./)) return true;
+  if (ip.startsWith("169.254.")) return true;
+  if (ip.startsWith("fc00:") || ip.startsWith("fd00:")) return true;
+  if (ip.startsWith("fe80:")) return true;
+  return false;
+}
 
 export interface HttpClient {
   /**
@@ -70,7 +84,20 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
+              const hostname = options.url.hostname;
+              if (isPrivateIp(hostname)) {
+                throw new Error(`SSRF Attempt blocked: ${hostname}`);
+              }
+              try {
+                const lookup = await dns.lookup(hostname);
+                if (isPrivateIp(lookup.address)) {
+                  throw new Error(`SSRF Attempt blocked (DNS resolution): ${lookup.address}`);
+                }
+              } catch (e: any) {
+                if (e.message.includes("SSRF Attempt blocked")) throw e;
+              }
+
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The web scraper (`WebScrapingServiceImpl` -> `CosmicHttpClient`) checked URL validity (`isValidUrl`) by only ensuring it had an HTTP/HTTPS scheme, but failed to verify the resolved IP address. This allowed attackers to perform SSRF attacks by providing domains that resolved to internal IP addresses (e.g., `localtest.me` pointing to `::1`) or providing internal IP literals directly (e.g., AWS metadata endpoint `http://169.254.169.254/`).
🎯 Impact: Attackers could potentially access internal microservices, loopback APIs, or cloud provider metadata endpoints (which can expose sensitive AWS IAM credentials), leading to a full system compromise.
🔧 Fix: We used the `got` library's `hooks.beforeRequest` capabilities in `packages/shared/src/services/http-client.ts`. A custom `isPrivateIp` function was written using the Node.js `net` package to detect internal IPs. The hook now parses the destination hostname, verifies it doesn't represent an internal IP literal, and then synchronously performs a DNS lookup (`dns.promises.lookup`). If the resolved IP maps to a private/internal block, the request is immediately aborted before it can be sent.
✅ Verification: Tested against a local Next.js web application and other loopback mechanisms. All tests in `packages/shared` pass without error.

---
*PR created automatically by Jules for task [15248443997169604965](https://jules.google.com/task/15248443997169604965) started by @pffreitas*