### PR TITLE
🎨 Palette: Add keyboard shortcut tooltip to New Bookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2025-01-20 - Cross-platform shortcut tooltips
+**Learning:** Users need discoverability for keyboard shortcuts. Hardcoded metaKey shortcuts break accessibility on Windows/Linux, and using raw navigator.platform during SSR causes hydration mismatches.
+**Action:** Always check both metaKey and ctrlKey for global shortcuts. Initialize client-side platform state (like `isMac`) inside a useEffect hook, and expose the shortcut via a semantic `<kbd>` element within a tooltip.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -19,13 +25,14 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
-    (state) => state.bookmarks.createLoading
+    (state) => state.bookmarks.createLoading,
   );
   const previewLoading = useAppSelector(
-    (state) => state.bookmarks.previewLoading
+    (state) => state.bookmarks.previewLoading,
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
@@ -41,9 +48,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
       const preview = result.payload as PreviewResponse;
 
       if (preview.scrapable) {
-        const createResult = await dispatch(
-          createBookmark({ sourceUrl: url })
-        );
+        const createResult = await dispatch(createBookmark({ sourceUrl: url }));
         if (createBookmark.fulfilled.match(createResult)) {
           setShowOverlay(false);
           setUrl("");
@@ -76,8 +81,14 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(
+      typeof window !== "undefined"
+        ? navigator.platform.toUpperCase().indexOf("MAC") >= 0
+        : false,
+    );
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +146,32 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent>
+              <p className="flex items-center gap-1">
+                Save Bookmark
+                <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+                  <span className="text-xs">{isMac ? "⌘" : "Ctrl"}</span>K
+                </kbd>
+              </p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }


### PR DESCRIPTION
💡 **What:** Added a tooltip to the "New Bookmark" button that dynamically displays the cross-platform keyboard shortcut (`⌘K` on Mac, `CtrlK` on Windows/Linux).
🎯 **Why:** Global keyboard shortcuts are hidden interactions. Users lack discoverability of the `Cmd+K` shortcut, and hardcoded `metaKey` checks exclude Windows/Linux users from utilizing the shortcut entirely.
📸 **Before/After:** No visual change by default; when hovering the "Save Bookmark" button, an accessible tooltip now displays "Save Bookmark [⌘K/CtrlK]".
♿ **Accessibility:** Added cross-platform functionality (Ctrl fallback) and wrapped the hint in semantic `<kbd>` tags. Handled client-side OS detection carefully to avoid Next.js hydration mismatches.

---
*PR created automatically by Jules for task [9442434487528778139](https://jules.google.com/task/9442434487528778139) started by @pffreitas*