### PR TITLE
🛡️ Sentinel: [HIGH] Fix Server-Side Request Forgery (SSRF) in URL validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2025-05-25 - Server-Side Request Forgery via Insufficient URL Validation
+**Vulnerability:** The web scraping service accepted any URL starting with http:// or https:// without verifying if the domain resolved to an internal IP address (like 127.0.0.1, localhost, or 169.254.169.254 for AWS metadata).
+**Learning:** Relying solely on static string or Regex checks against `new URL(url).hostname` is vulnerable to DNS-based bypasses (e.g., `localtest.me` resolving to `127.0.0.1`). Comprehensive prevention requires resolving the hostname to an IP address prior to the request. Node.js `new URL()` automatically normalizes some IP formats, but explicit IP checking and DNS resolution is required.
+**Prevention:** Implement an async check that parses the URL, validates it's not a private IP string, and performs an explicit DNS lookup to verify the resolved IP is not an internal or loopback address before fetching.

--- a/apps/api/src/routes/bookmarks.ts
+++ b/apps/api/src/routes/bookmarks.ts
@@ -54,7 +54,7 @@ export default async function bookmarkRoutes(fastify: FastifyInstance) {
           return reply.status(400).send({ error: "source_url is required" });
         }
 
-        if (!services.webScraping.isValidUrl(source_url)) {
+        if (!(await services.webScraping.isValidUrl(source_url))) {
           return reply.status(400).send({ error: "Invalid URL format" });
         }
 
@@ -219,7 +219,7 @@ export default async function bookmarkRoutes(fastify: FastifyInstance) {
         return reply.status(400).send({ error: "url is required" });
       }
 
-      if (!services.webScraping.isValidUrl(url)) {
+      if (!(await services.webScraping.isValidUrl(url))) {
         return reply.status(400).send({ error: "Invalid URL format" });
       }
 

--- a/apps/api/src/tests/bookmark.test.ts
+++ b/apps/api/src/tests/bookmark.test.ts
@@ -5,29 +5,32 @@ describe("Bookmark Feature Validation", () => {
   describe("URL validation", () => {
     const webScrapingService = new WebScrapingServiceImpl();
 
-    it("should validate valid URLs", () => {
+    it("should validate valid URLs", async () => {
       const validUrls = [
         "https://example.com",
         "http://test.org",
         "https://www.domain.com/path?query=1",
       ];
 
-      validUrls.forEach((url) => {
-        expect(webScrapingService.isValidUrl(url)).toBe(true);
-      });
+      for (const url of validUrls) {
+        expect(await webScrapingService.isValidUrl(url)).toBe(true);
+      }
     });
 
-    it("should reject invalid URLs", () => {
+    it("should reject invalid URLs", async () => {
       const invalidUrls = [
         "not-a-url",
         "ftp://invalid-protocol.com",
         "invalid://test.com",
         "",
+        "http://localhost:3000",
+        "http://127.0.0.1",
+        "http://169.254.169.254"
       ];
 
-      invalidUrls.forEach((url) => {
-        expect(webScrapingService.isValidUrl(url)).toBe(false);
-      });
+      for (const url of invalidUrls) {
+        expect(await webScrapingService.isValidUrl(url)).toBe(false);
+      }
     });
   });
 

--- a/packages/shared/src/services/web-scraping.service.ts
+++ b/packages/shared/src/services/web-scraping.service.ts
@@ -11,7 +11,7 @@ import { YouTubeService, YouTubeServiceImpl } from "./youtube.service";
 import { TwitterService, TwitterServiceImpl } from "./twitter.service";
 
 export interface WebScrapingService {
-  isValidUrl(url: string): boolean;
+  isValidUrl(url: string): Promise<boolean>;
   scrape(
     url: string
   ): Promise<
@@ -37,10 +37,41 @@ export class WebScrapingServiceImpl implements WebScrapingService {
     this.twitterService = twitterService ?? new TwitterServiceImpl(httpClient);
   }
 
-  isValidUrl(url: string): boolean {
+  async isValidUrl(url: string): Promise<boolean> {
     try {
       const urlObj = new URL(url);
-      return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+      if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+        return false;
+      }
+      const hostname = urlObj.hostname;
+
+      if (hostname === "localhost" || hostname.endsWith(".local")) {
+        return false;
+      }
+
+      const isInternalIp = (ip: string) => {
+        return (
+          ip === "127.0.0.1" ||
+          ip === "::1" ||
+          ip.startsWith("10.") ||
+          ip.startsWith("192.168.") ||
+          /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip) ||
+          ip === "0.0.0.0" ||
+          ip.startsWith("169.254.")
+        );
+      };
+
+      if (isInternalIp(hostname)) return false;
+
+      try {
+        const dns = require("node:dns/promises");
+        const lookup = await dns.lookup(hostname);
+        if (isInternalIp(lookup.address)) return false;
+      } catch (e) {
+        // DNS lookup failure
+      }
+
+      return true;
     } catch {
       return false;
     }

--- a/test-got.ts
+++ b/test-got.ts
@@ -1,0 +1,10 @@
+const got = require("got");
+async function run() {
+  try {
+    const res = await got("http://127.0.0.1:3001");
+    console.log("Success:", res.statusCode);
+  } catch (err) {
+    console.log("Error:", err.message);
+  }
+}
+run();


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF). The web scraping service accepted any URL starting with `http://` or `https://` without checking if the domain resolved to an internal/private IP address.
🎯 **Impact:** An attacker could craft a bookmark request with a URL pointing to internal network addresses (e.g., `127.0.0.1:5432`, internal AWS metadata endpoint `169.254.169.254`, etc.) and the application would make requests to these endpoints, potentially leaking internal data or sending unauthorized commands.
🔧 **Fix:** Refactored `isValidUrl` in `WebScrapingService` to perform asynchronous DNS resolution and check the resolved IP against a blocklist of internal IPs/subnets (127.0.0.1, 10.x.x.x, etc.). Adapted the calling routes and tests to correctly await the new asynchronous check.
✅ **Verification:** Verify by adding a bookmark with `http://localhost:3000` or `http://localtest.me` (which resolves to 127.0.0.1) and confirm that the API returns a 400 Bad Request error.

---
*PR created automatically by Jules for task [7183403663325859475](https://jules.google.com/task/7183403663325859475) started by @pffreitas*