### PR TITLE
🎨 Palette: Add keyboard shortcut hint to new bookmark button

### DIFF
--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,10 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
 export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const [showOverlay, setShowOverlay] = useState(false);
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
@@ -76,8 +78,12 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +141,37 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="flex items-center gap-2">
+              Save Bookmark
+              {isMac !== null && (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+                    {isMac ? "⌘" : "Ctrl"}
+                  </kbd>
+                  <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+                    K
+                  </kbd>
+                </span>
+              )}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 **What**: Added a tooltip to the "Save Bookmark" button containing cross-platform keyboard shortcut hints (⌘ K for macOS, Ctrl K for others), wrapped in accessible `<kbd>` tags. It also updates the existing shortcut listener from strictly matching `metaKey` to now matching `metaKey` or `ctrlKey` for Windows/Linux users.
🎯 **Why**: Improves discoverability of existing but hidden shortcuts, making navigation and rapid saving easier for power users across all operating systems. It increases visual polish matching standard patterns in the app (like the search bar).
📸 **Before/After**: N/A - The core UI remains the same until hovered, where a helpful native tooltip now appears.
♿ **Accessibility**: Enhanced shortcut hinting with screen reader-friendly `<kbd>` tags and safe client-side initialization to prevent hydration warnings.

---
*PR created automatically by Jules for task [5591952550921733616](https://jules.google.com/task/5591952550921733616) started by @pffreitas*