### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in web scraper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-30 - SSRF Vulnerability in Got Client DNS Resolution
+**Vulnerability:** The HTTP client allowed SSRF via redirects or direct requests to internal IPs (like `127.0.0.1` or `localhost`) since URLs were not validated for internal resolution prior to dispatching requests.
+**Learning:** Relying solely on static string or Regex checks against `new URL(url).hostname` is vulnerable to DNS-based bypasses (e.g., `localtest.me` resolving to `127.0.0.1`). Comprehensive prevention requires resolving the hostname to an IP address prior to the request using the `dns` module to check for internal IPs.
+**Prevention:** Ensure any server-side HTTP request handlers validate the resolved IP address of the target URL against an internal IP blocklist before performing the request.

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,4 +1,19 @@
 const got = require("got").default || require("got");
+import * as dns from "dns";
+import { promisify } from "util";
+
+const lookupAsync = promisify(dns.lookup);
+
+function isInternalIp(ip: string): boolean {
+  if (ip === "127.0.0.1" || ip === "::1" || ip === "0.0.0.0") return true;
+  if (ip.startsWith("10.")) return true;
+  if (/^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip)) return true;
+  if (ip.startsWith("192.168.")) return true;
+  if (ip.startsWith("169.254.")) return true;
+  if (ip.startsWith("fc") || ip.startsWith("fd")) return true;
+  if (ip.startsWith("fe80:")) return true;
+  return false;
+}
 
 export interface HttpClient {
   /**
@@ -70,7 +85,22 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
+              const hostname = options.url.hostname;
+
+              // 🛡️ Sentinel: Block SSRF vulnerabilities by ensuring resolving to an IP isn't internal
+              if (isInternalIp(hostname)) {
+                throw new Error("SSRF Blocked: URL resolved to an internal IP address");
+              }
+              try {
+                const { address } = await lookupAsync(hostname);
+                if (isInternalIp(address)) {
+                  throw new Error(`SSRF Blocked: URL resolved to an internal IP address`);
+                }
+              } catch (e: any) {
+                if (e.message.includes("SSRF")) throw e;
+              }
+
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `WebScrapingServiceImpl` fetched user-provided URLs using `got` without validating if the resolved IP address belonged to an internal or private network block, allowing Server-Side Request Forgery (SSRF). Attackers could provide internal domains, raw IPs (e.g., `127.0.0.1`), obfuscated IPs (e.g., `2130706433`), or domains resolving to internal networks via DNS rebinding (e.g., `localtest.me`) to access internal resources.
🎯 **Impact:** Allowed external attackers to probe internal services, access cloud metadata endpoints (like AWS `169.254.169.254`), or pivot attacks into the server's local network.
🔧 **Fix:** Added a `beforeRequest` hook to the `CosmicHttpClient` `got` configuration. The hook explicitly checks the normalized URL hostname and resolves the hostname via `dns.lookup`. If either the hostname or resolved IP match internal network IP patterns, the request is actively blocked and throws an `SSRF Blocked` error.
✅ **Verification:** Verified via local proxy scripts and unit tests that external requests proceed normally, while localhost and internal IPs are correctly blocked.

---
*PR created automatically by Jules for task [16803873394392957332](https://jules.google.com/task/16803873394392957332) started by @pffreitas*