### PR TITLE
🎨 Palette: Add keyboard shortcut tooltip to New Bookmark button

### DIFF
--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -29,6 +35,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   );
   const createError = useAppSelector((state) => state.bookmarks.createError);
   const previewError = useAppSelector((state) => state.bookmarks.previewError);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
 
   const isLoading = createLoading || previewLoading;
 
@@ -76,8 +83,10 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +144,35 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent side="bottom" className="flex items-center gap-1.5 text-xs">
+              <span>Save Bookmark</span>
+              <span className="flex items-center gap-0.5 opacity-70">
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-black/20 border-white/20">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-black/20 border-white/20">
+                  K
+                </kbd>
+              </span>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }


### PR DESCRIPTION
💡 What: Added a hover tooltip to the "Save Bookmark" button that displays the keyboard shortcut (`⌘K` or `Ctrl+K`), dynamically detecting the user's OS to show the correct modifier key. Also improved the keyboard event listener to support Windows/Linux users with `Ctrl+K` in addition to the existing `Cmd+K`.
🎯 Why: Hidden keyboard shortcuts are a major accessibility and discoverability issue. Adding a visual hint helps power users learn the shortcut without needing to consult documentation. Updating the event listener makes the shortcut cross-platform functional.
📸 Before/After: Before: Hovering the "Save Bookmark" button did nothing. After: Hovering displays a tooltip indicating the action and the OS-specific keyboard shortcut (`⌘K` on Mac, `Ctrl K` on Windows/Linux) using semantic `<kbd>` tags.
♿ Accessibility: Ensures the keyboard shortcut works for all OS users. Wraps the shortcut hint in semantic `<kbd>` tags for screen readers. Added `focus-visible` styling to the button to improve keyboard navigation visibility.

---
*PR created automatically by Jules for task [9808792158078238182](https://jules.google.com/task/9808792158078238182) started by @pffreitas*