### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in web scraping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-30 - DNS Rebinding and SSRF Bypass via Alternate IP Formats
+**Vulnerability:** The HTTP client allowed arbitrary outbound requests without checking if the target URL resolved to an internal IP address or using alternate formats like `http://2130706433/` or `localtest.me`.
+**Learning:** When mitigating SSRF vulnerabilities in Node.js, relying solely on static string or Regex checks against `new URL(url).hostname` is vulnerable to DNS-based bypasses (e.g., `localtest.me` resolving to `127.0.0.1`). Comprehensive prevention requires resolving the hostname to an IP address prior to the request or using network-level egress controls.
+**Prevention:** Always perform a DNS lookup (`dns.promises.lookup`) on the target hostname and validate the resolved IP address against a blocklist of private and loopback IP ranges before making the request.

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,3 +1,6 @@
+import * as net from "net";
+import * as dns from "dns";
+
 const got = require("got").default || require("got");
 
 export interface HttpClient {
@@ -70,10 +73,51 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );
+
+              const hostname = options.url.hostname;
+              const isInternalIp = (ip: string): boolean => {
+                if (!net.isIP(ip)) return false;
+                if (ip.startsWith("127.")) return true;
+                if (ip.startsWith("10.")) return true;
+                if (ip.startsWith("192.168.")) return true;
+                if (/^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip)) return true;
+                if (ip === "0.0.0.0") return true;
+                if (ip === "::1") return true;
+                if (ip.toLowerCase().startsWith("fc") || ip.toLowerCase().startsWith("fd")) return true;
+                if (ip.toLowerCase().startsWith("fe8") || ip.toLowerCase().startsWith("fe9") ||
+                    ip.toLowerCase().startsWith("fea") || ip.toLowerCase().startsWith("feb")) return true;
+                if (ip.toLowerCase().startsWith("::ffff:")) {
+                  const ipv4 = ip.split(":").pop();
+                  return ipv4 ? isInternalIp(ipv4) : false;
+                }
+                return false;
+              };
+
+              if (hostname === "localhost" || hostname.endsWith(".local") || hostname.includes("internal")) {
+                throw new Error("SSRF Prevention: Internal hostnames are not allowed");
+              }
+
+              try {
+                const cleanHost = hostname.replace(/^\[|\]$/g, "");
+                const lookupResult = await dns.promises.lookup(cleanHost);
+                if (isInternalIp(lookupResult.address)) {
+                  throw new Error("SSRF Prevention: Internal IPs are not allowed");
+                }
+
+                // Override the hostname to use the resolved IP to prevent DNS rebinding
+                // TOCTOU attacks
+                options.url.hostname = lookupResult.address;
+                options.headers.host = hostname; // preserve original host header
+              } catch (err: any) {
+                if (err.message.includes("SSRF Prevention")) throw err;
+
+                // If DNS lookup fails for other reasons, we fail closed
+                throw new Error(`SSRF Prevention: Failed to resolve hostname: ${err.message}`);
+              }
             },
           ],
           afterResponse: [


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `CosmicHttpClient` (used by the `/bookmarks/preview` web scraping endpoint) fetched arbitrary target URLs without enforcing any network-level egress restrictions. An attacker could exploit Server-Side Request Forgery (SSRF) to scan internal networks, reach `localhost`, or hit sensitive internal APIs (e.g., AWS metadata). String-based validation checks on URLs can be bypassed via alternative IP representations (e.g. `http://2130706433/` for `127.0.0.1`) and DNS resolution of external domains pointing to internal loopback addresses (like `localtest.me`).
🎯 Impact: This could be exploited to scan internal servers, steal cloud metadata credentials, or interact with unauthenticated microservices in the same VPC.
🔧 Fix: Added a `beforeRequest` hook to `CosmicHttpClient` (in `packages/shared/src/services/http-client.ts`) that intercepts the outbound request, blocks `localhost`/`.local` outright, and resolves the target hostname using `dns.promises.lookup`. If the resolved IP address matches private (RFC1918) or loopback IPv4/IPv6 ranges, the request is aborted. To prevent DNS rebinding (TOCTOU attacks), the request's hostname is then explicitly rewritten to the resolved, validated IP address, whilst maintaining the original `Host` HTTP header. 
✅ Verification: `cd packages/shared && bun run tsc --noEmit` and running unit tests using `cd packages/shared && SKIP_DB=true bun test src/__tests__/services/web-scraping.service.test.ts`. Also tested standalone with diverse SSFR evasion hostnames to confirm they're actively blocked.

---
*PR created automatically by Jules for task [6101456503566300330](https://jules.google.com/task/6101456503566300330) started by @pffreitas*