### PR TITLE
🎨 Palette: Add cross-platform keyboard shortcut tooltip to new bookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2024-10-18 - Cross-Platform Keyboard Shortcuts and Discoverability
+**Learning:** Using only `event.metaKey` for keyboard shortcuts limits accessibility by breaking functionality on Windows/Linux devices, which expect `event.ctrlKey`. Furthermore, hidden global shortcuts reduce discoverability; primary action buttons should expose these shortcuts visually to the user.
+**Action:** Always check `(event.metaKey || event.ctrlKey)` in keyboard event listeners for cross-platform support, and use a `TooltipProvider` to display conditionally rendered, OS-aware shortcut hints (`⌘` vs `Ctrl`) inside semantic `<kbd>` tags on the respective buttons.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,7 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -21,6 +22,13 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
+
+  const [isMac, setIsMac] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
+
   const createLoading = useAppSelector(
     (state) => state.bookmarks.createLoading
   );
@@ -77,7 +85,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +143,35 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" align="center" className="flex items-center gap-2">
+            <span>Save Bookmark</span>
+            {isMac !== null && (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground ml-1">
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+                  K
+                </kbd>
+              </span>
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 What: Wrapped the "Save Bookmark" button in a tooltip displaying an OS-aware keyboard shortcut (`⌘K` for Mac, `Ctrl+K` for Windows/Linux) and updated the global event listener to support `ctrlKey` as a fallback. Added a delay of 300ms to the tooltip.
🎯 Why: Hidden global shortcuts reduce discoverability. Also, relying solely on `event.metaKey` breaks cross-platform accessibility since Windows/Linux users typically use `Ctrl` instead of the Windows key.
📸 Before/After: Visual tooltip showing shortcut hints added to main primary action.
♿ Accessibility: Increased accessibility for non-Mac users by respecting standard platform modifier keys. Added semantic `<kbd>` tags.

---
*PR created automatically by Jules for task [4770753623710593571](https://jules.google.com/task/4770753623710593571) started by @pffreitas*