### PR TITLE
🎨 Palette: Add ARIA label to scroll-to-bottom button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+## 2025-06-01 - Add ARIA label to scroll-to-bottom button
+**Learning:** Icon-only buttons used for navigation or actions within complex interactive components (like a chat interface) often lack context for screen reader users, making the application less accessible.
+**Action:** Always ensure that icon-only `Button` components are accompanied by an `aria-label` attribute describing their specific action to improve accessibility and provide a clear, understandable experience for all users.

--- a/apps/web/components/ai-elements/conversation.tsx
+++ b/apps/web/components/ai-elements/conversation.tsx
@@ -88,6 +88,7 @@ export const ConversationScrollButton = ({
         size="icon"
         type="button"
         variant="outline"
+        aria-label="Scroll to bottom"
         {...props}
       >
         <ArrowDownIcon className="size-4" />


### PR DESCRIPTION
💡 What: Added an `aria-label="Scroll to bottom"` to the icon-only `Button` component in `ConversationScrollButton`.
🎯 Why: To provide context for screen reader users, making the application more accessible.
📸 Before/After: N/A (Non-visual change, purely accessibility metadata).
♿ Accessibility: Improved screen reader navigation by ensuring all interactive icon-only buttons have explicit, descriptive ARIA labels.

---
*PR created automatically by Jules for task [4188987785338500709](https://jules.google.com/task/4188987785338500709) started by @pffreitas*