### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in HTTP Client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-25 - DNS Rebinding Vulnerability in HTTP Client SSRF Protection
+**Vulnerability:** Mitigating SSRF by solely validating the hostname via string matching or initial DNS resolution leaves a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where an attacker can rapidly change DNS records after validation but before the request.
+**Learning:** Overriding the HTTP client's request hostname with the validated IP address is required to prevent DNS rebinding attacks. However, this causes HTTPS requests to fail due to incorrect Server Name Indication (SNI) during the TLS handshake.
+**Prevention:** Override `options.url.hostname` with the validated IP and explicitly set the original hostname in `options.headers.host` and `options.https.servername` to ensure both DNS rebinding protection and valid TLS handshakes.

--- a/packages/shared/src/__tests__/services/http-client.test.ts
+++ b/packages/shared/src/__tests__/services/http-client.test.ts
@@ -1,0 +1,23 @@
+import { CosmicHttpClient } from "../../services/http-client";
+
+describe("CosmicHttpClient SSRF Prevention", () => {
+  it("should block requests to localhost via IPv4", async () => {
+    const client = new CosmicHttpClient();
+    await expect(client.fetch("http://127.0.0.1:3000")).rejects.toThrow(/SSRF Validation Failed/);
+  });
+
+  it("should block requests to localhost via DNS", async () => {
+    const client = new CosmicHttpClient();
+    await expect(client.fetch("http://localhost:3000")).rejects.toThrow(/SSRF Validation Failed/);
+  });
+
+  it("should block requests to cloud metadata service", async () => {
+    const client = new CosmicHttpClient();
+    await expect(client.fetch("http://169.254.169.254")).rejects.toThrow(/SSRF Validation Failed/);
+  });
+
+  it("should block requests to localhost via IPv6 literal", async () => {
+    const client = new CosmicHttpClient();
+    await expect(client.fetch("http://[::1]:3000")).rejects.toThrow(/SSRF Validation Failed/);
+  });
+});

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,4 +1,63 @@
 const got = require("got").default || require("got");
+const dns = require("dns");
+const net = require("net");
+
+async function resolveAndValidateIp(hostname: string): Promise<string> {
+  // Strip brackets if it's an IPv6 literal before processing
+  const cleanHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+
+  let ipToValidate = cleanHostname;
+
+  if (!net.isIP(cleanHostname)) {
+    try {
+      const lookupResult = await dns.promises.lookup(cleanHostname);
+      ipToValidate = lookupResult.address;
+    } catch (error) {
+      throw new Error(`DNS resolution failed for ${cleanHostname}`);
+    }
+  }
+
+  if (ipToValidate.startsWith('::ffff:')) {
+    ipToValidate = ipToValidate.substring(7);
+  }
+
+  if (ipToValidate === '::' || ipToValidate === '0.0.0.0') {
+    throw new Error(`SSRF Validation Failed: Internal IP address not allowed`);
+  }
+
+  const isIPv4 = net.isIPv4(ipToValidate);
+
+  if (isIPv4) {
+    const parts = ipToValidate.split('.').map(Number);
+    if (
+      parts[0] === 127 ||
+      parts[0] === 10 ||
+      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+      (parts[0] === 192 && parts[1] === 168) ||
+      parts[0] === 169 && parts[1] === 254
+    ) {
+      throw new Error(`SSRF Validation Failed: Internal IP address not allowed`);
+    }
+  } else if (net.isIPv6(ipToValidate)) {
+    const normalized = ipToValidate.toLowerCase();
+    if (
+      normalized === '::1' ||
+      normalized.startsWith('fc') || normalized.startsWith('fd') ||
+      normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')
+    ) {
+      throw new Error(`SSRF Validation Failed: Internal IP address not allowed`);
+    }
+
+    // Add brackets for Node's URL parser if it doesn't already have them
+    if (!ipToValidate.startsWith('[')) {
+      ipToValidate = `[${ipToValidate}]`;
+    }
+  }
+
+  return ipToValidate;
+}
 
 export interface HttpClient {
   /**
@@ -70,10 +129,25 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );
+
+              const originalHostname = options.url.hostname;
+              const ip = await resolveAndValidateIp(originalHostname);
+
+              // Override hostname to prevent DNS rebinding
+              options.url.hostname = ip;
+
+              // Preserve original host header
+              options.headers.host = originalHostname;
+
+              // Fix SNI for HTTPS requests
+              if (options.url.protocol === 'https:' && !net.isIP(originalHostname)) {
+                options.https = options.https || {};
+                options.https.servername = originalHostname;
+              }
             },
           ],
           afterResponse: [


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `CosmicHttpClient` was vulnerable to Server-Side Request Forgery (SSRF) and Time-of-Check to Time-of-Use (TOCTOU) DNS rebinding attacks. It was possible for an attacker to send requests to internal or protected IP addresses.
🎯 Impact: This vulnerability could allow an attacker to make arbitrary internal HTTP requests.
🔧 Fix: Implemented an SSRF protection middleware in the HTTP client. The middleware resolves hostnames to an IP address, validates the IP against known private/internal ranges (including IPv6 and cloud metadata endpoints), and overrides `url.hostname` with the validated IP to prevent DNS rebinding. Added proper IPv6 bracketed literal parsing. 
✅ Verification: Tested against standard internal IPs and DNS rebinding scenarios to ensure they fail securely. Tested IPv6 literals to ensure they parse appropriately without crashing the client.

---
*PR created automatically by Jules for task [18009822232618897215](https://jules.google.com/task/18009822232618897215) started by @pffreitas*