### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in web scraper

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2026-05-10 - Server-Side Request Forgery via DNS Rebinding
+**Vulnerability:** The web scraper (`CosmicHttpClient`) allowed fetching arbitrary URLs without resolving them first, which bypassed basic string validation and allowed DNS rebinding to internal IPs (like `localtest.me` resolving to `127.0.0.1`).
+**Learning:** Mitigating SSRF requires resolving hostnames to IP addresses prior to making the request, rather than just parsing the URL. Overriding the request URL's hostname with the validated IP is necessary to prevent TOCTOU (Time-Of-Check to Time-Of-Use) vulnerabilities while correctly setting the TLS `servername`.
+**Prevention:** Always use `dns.lookup` to resolve hostnames before making HTTP requests and block any requests attempting to access internal or loopback IP ranges.

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,4 +1,37 @@
 const got = require("got").default || require("got");
+import * as dns from "dns";
+import * as net from "net";
+import { promisify } from "util";
+
+const lookup = promisify(dns.lookup);
+
+function isInternalIP(ip: string): boolean {
+  if (ip.startsWith("::ffff:")) ip = ip.substring(7);
+  if (net.isIPv4(ip)) {
+    const parts = ip.split(".").map(Number);
+    return (
+      parts[0] === 127 ||
+      parts[0] === 10 ||
+      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+      (parts[0] === 192 && parts[1] === 168) ||
+      (parts[0] === 169 && parts[1] === 254) ||
+      parts[0] === 0
+    );
+  } else if (net.isIPv6(ip)) {
+    const lower = ip.toLowerCase();
+    return (
+      lower === "::1" ||
+      lower === "::" ||
+      lower.startsWith("fc") ||
+      lower.startsWith("fd") ||
+      lower.startsWith("fe8") ||
+      lower.startsWith("fe9") ||
+      lower.startsWith("fea") ||
+      lower.startsWith("feb")
+    );
+  }
+  return false;
+}
 
 export interface HttpClient {
   /**
@@ -70,10 +103,38 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );
+
+              let originalHostname = options.url.hostname;
+              if (originalHostname.startsWith('[') && originalHostname.endsWith(']')) {
+                originalHostname = originalHostname.slice(1, -1);
+              }
+
+              if (isInternalIP(originalHostname)) {
+                throw new Error("SSRF Protection: Access to internal IP blocked");
+              }
+
+              if (!net.isIP(originalHostname)) {
+                const { address } = await lookup(originalHostname);
+
+                if (isInternalIP(address)) {
+                  throw new Error("SSRF Protection: Access to internal IP blocked");
+                }
+
+                if (!options.headers.host && !options.headers.Host) {
+                  options.headers.host = options.url.host;
+                }
+
+                if (options.url.protocol === 'https:') {
+                  options.https = options.https || {};
+                  options.https.servername = originalHostname;
+                }
+
+                options.url.hostname = net.isIPv6(address) ? `[${address}]` : address;
+              }
             },
           ],
           afterResponse: [


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `CosmicHttpClient` used by the web scraping service passed user-supplied URLs directly to `got` without validating the resolved IP address. This allowed SSRF (Server-Side Request Forgery) attacks via DNS rebinding (e.g., `localtest.me` resolving to `127.0.0.1` or attacker-controlled DNS changing responses with short TTLs), granting access to internal network resources.
🎯 Impact: Attackers could scan internal networks, access loopback services, read internal metadata APIs (e.g., AWS/GCP instance metadata), and potentially exploit internal vulnerabilities bypassing network firewalls.
🔧 Fix: Implemented strict DNS resolution inside a `beforeRequest` hook in the `got` client. The application now uses `dns.lookup` to resolve the hostname and validates the resulting IP against a comprehensive list of internal/loopback ranges. To prevent TOCTOU (Time-Of-Check to Time-Of-Use) bypasses, the request strictly connects to the validated IP, while the `Host` header and TLS SNI (`servername`) are explicitly preserved to ensure external HTTPS sites do not break.
✅ Verification: Tested against `127.0.0.1`, `localhost`, `[::1]`, and internal network ranges. Verified `got` throws SSRF errors. Evaluated tests pass. Cleaned up scratchpad testing files.

---
*PR created automatically by Jules for task [6852275254527089381](https://jules.google.com/task/6852275254527089381) started by @pffreitas*