### PR TITLE
🎨 Palette: Add keyboard shortcut tooltip to Save Bookmark button

### DIFF
--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,10 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
 export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const [showOverlay, setShowOverlay] = useState(false);
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
@@ -76,8 +78,12 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +141,35 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent>
+              <span className="flex items-center gap-1 text-xs">
+                New bookmark
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200 text-gray-500 ml-1">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200 text-gray-500">
+                  K
+                </kbd>
+              </span>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 What: Added safe OS detection (`isMac` initialized to `null` and set via `useEffect`) and a helpful `Tooltip` displaying the correct platform-specific shortcut (`⌘K` vs `CtrlK`) to the 'Save Bookmark' button. Also updated the actual keyboard event listener to support Windows/Linux users by checking for `event.ctrlKey` in addition to `event.metaKey`.

🎯 Why: Discoverability and accessibility. The keyboard shortcut was completely hidden from users, and only worked on macOS. The tooltip safely renders after hydration to avoid SSR mismatch errors, and wraps the hints in semantic `<kbd>` tags.

♿ Accessibility: The keyboard hints are wrapped in semantic `<kbd>` HTML elements for screen readers.

---
*PR created automatically by Jules for task [16692207579827964333](https://jules.google.com/task/16692207579827964333) started by @pffreitas*