### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in CosmicHttpClient

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-06-08 - SSRF Vulnerability in Got HTTP Client
+**Vulnerability:** The `CosmicHttpClient` used unconstrained requests via the `got` library, allowing users to provide URLs that map to internal services (e.g., `http://localhost:3000`, `http://127.0.0.1`), leading to Server-Side Request Forgery (SSRF) vulnerabilities.
+**Learning:** Relying solely on `new URL(url).hostname` checks is insufficient as it is vulnerable to DNS rebinding (Time-Of-Check to Time-Of-Use). You must resolve the IP address, validate it against a blocklist, and explicitly override the request URL's hostname with the validated IP while preserving the original `Host` and TLS `servername` to prevent SNI errors.
+**Prevention:** Implement a `beforeRequest` hook in the HTTP client to explicitly perform a DNS lookup, enforce an IP blocklist against private/internal IP ranges, and securely structure the request using the resolved IP.

--- a/packages/shared/src/__mocks__/got.ts
+++ b/packages/shared/src/__mocks__/got.ts
@@ -1,6 +1,23 @@
 // Mock implementation of got for testing
-const mockGot = jest.fn().mockImplementation((url: string, options?: any) => {
+const mockGot = jest.fn().mockImplementation(async (url: string, options?: any) => {
+  // Execute hooks if provided
+  if (options?.hooks?.beforeRequest) {
+    for (const hook of options.hooks.beforeRequest) {
+      // The original library mutates URL by reference
+      const urlObj = new URL(url);
+      const fakeOptions = {
+        url: urlObj,
+        headers: { ...options?.headers }
+      };
+      await hook(fakeOptions);
+      // Update back URL just in case
+      url = fakeOptions.url.toString();
+    }
+  }
+
   return Promise.resolve({
+    url: url,
+    requestUrl: url,
     statusCode: 200,
     statusMessage: "OK",
     headers: {

--- a/packages/shared/src/__tests__/services/http-client.test.ts
+++ b/packages/shared/src/__tests__/services/http-client.test.ts
@@ -1,0 +1,23 @@
+import { CosmicHttpClient } from "../../services/http-client";
+
+describe("CosmicHttpClient", () => {
+  let client: CosmicHttpClient;
+
+  beforeEach(() => {
+    client = new CosmicHttpClient();
+  });
+
+  it("should block requests to private IPv4 addresses", async () => {
+    await expect(client.fetch("http://127.0.0.1:3000")).rejects.toThrow(/SSRF blocked/);
+    await expect(client.fetch("http://10.0.0.1")).rejects.toThrow(/SSRF blocked/);
+    await expect(client.fetch("http://192.168.1.1")).rejects.toThrow(/SSRF blocked/);
+  });
+
+  it("should block requests to private IPv6 addresses", async () => {
+    await expect(client.fetch("http://[::1]")).rejects.toThrow(/SSRF blocked/);
+  });
+
+  it("should block requests to localhost via DNS lookup", async () => {
+    await expect(client.fetch("http://localhost:3000")).rejects.toThrow(/SSRF blocked/);
+  });
+});

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,4 +1,6 @@
 const got = require("got").default || require("got");
+import * as net from "net";
+import * as dns from "dns/promises";
 
 export interface HttpClient {
   /**
@@ -70,7 +72,68 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
+              const originalHostname = options.url.hostname;
+              const originalHost = options.url.host;
+
+              let ipToConnect = originalHostname;
+
+              if (!net.isIP(originalHostname)) {
+                try {
+                  const lookup = await dns.lookup(originalHostname);
+                  ipToConnect = lookup.address;
+                } catch (e) {
+                   // DNS lookup failed, let it fail naturally or block
+                }
+              }
+
+              let ipToCheck = ipToConnect;
+              if (ipToCheck.startsWith('::ffff:')) {
+                ipToCheck = ipToCheck.replace('::ffff:', '');
+              }
+
+              let isPrivate = false;
+              if (net.isIPv4(ipToCheck)) {
+                const parts = ipToCheck.split('.').map(Number);
+                if (
+                  parts[0] === 127 ||
+                  parts[0] === 10 ||
+                  (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+                  (parts[0] === 192 && parts[1] === 168) ||
+                  (parts[0] === 169 && parts[1] === 254) ||
+                  parts[0] === 0
+                ) {
+                  isPrivate = true;
+                }
+              } else if (net.isIPv6(ipToCheck)) {
+                if (
+                  ipToCheck === '::1' ||
+                  ipToCheck === '::' ||
+                  ipToCheck.toLowerCase().startsWith('fc') ||
+                  ipToCheck.toLowerCase().startsWith('fd') ||
+                  ipToCheck.toLowerCase().startsWith('fe8') ||
+                  ipToCheck.toLowerCase().startsWith('fe9') ||
+                  ipToCheck.toLowerCase().startsWith('fea') ||
+                  ipToCheck.toLowerCase().startsWith('feb')
+                ) {
+                  isPrivate = true;
+                }
+              }
+
+              if (isPrivate) {
+                throw new Error(`SSRF blocked: ${ipToConnect}`);
+              }
+
+              if (!net.isIP(originalHostname)) {
+                options.url.hostname = ipToConnect;
+                options.headers.host = originalHost;
+
+                if (options.url.protocol === 'https:') {
+                  options.https = options.https || {};
+                  options.https.servername = originalHostname;
+                }
+              }
+
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The `CosmicHttpClient` (which wraps `got`) previously resolved arbitrary URLs supplied to it without evaluating if the resolved target resided within the internal network. This allowed Server-Side Request Forgery (SSRF) and DNS rebinding attacks where an attacker could provide URLs (e.g., `http://127.0.0.1:3000` or `http://localhost`) that exploit the server to access internal services.

🎯 **Impact:**
An attacker could utilize scraping features or other functionality leveraging `CosmicHttpClient` to scan the internal network, bypass perimeter firewalls, and interact with internal administrative panels or services that do not require authentication from loopback addresses.

🔧 **Fix:**
Implemented a `beforeRequest` asynchronous hook in `got` that:
1. Performs an explicit DNS lookup on the target hostname.
2. Validates the resolved IP against a comprehensive blocklist of private IPv4 and IPv6 subnets.
3. Overrides the connection IP to use the validated address, neutralizing DNS rebinding attacks (Time-of-Check to Time-of-Use).
4. Persists the original HTTP `Host` header and sets the TLS `servername` option to ensure SNI-based routing on external targets remains functional.

✅ **Verification:**
1. Unit tests were implemented to specifically assert connections to `127.0.0.1`, `[::1]`, and internal subnets are proactively rejected.
2. Verified using `cd packages/shared && SKIP_DB=true npx jest ./src/__tests__/services/http-client.test.ts`.
3. Typechecked with `bun x tsc --noEmit`.

---
*PR created automatically by Jules for task [12306887009755902469](https://jules.google.com/task/12306887009755902469) started by @pffreitas*