### PR TITLE
🎨 Palette: Add keyboard shortcut hint to New Bookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+## 2025-06-08 - Keyboard Shortcut Tooltips
+**Learning:** Users often miss keyboard shortcuts. Adding a tooltip that conditionally displays the correct OS shortcut (⌘ vs Ctrl) improves discoverability without cluttering the UI, and React's hydration requires careful `isMac` state initialization on mount.
+**Action:** When adding global keyboard shortcuts to primary actions, always provide a tooltip hint displaying the correct OS-specific key combination.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,7 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -18,6 +19,11 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [showOverlay, setShowOverlay] = useState(false);
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
@@ -77,7 +83,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +141,37 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            id="new-bookmark-button"
+            className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+            onClick={() => {
+              handleNewBookmark();
+            }}
+          >
+            <Bookmark size={16} />
+            Save Bookmark
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <div className="flex items-center gap-2">
+            <span>New Bookmark</span>
+            {isMac !== null && (
+              <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                <kbd className="font-sans px-1 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1 py-0.5 rounded-md border bg-gray-50 border-gray-200">
+                  K
+                </kbd>
+              </span>
+            )}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
     </>
   );
 }


### PR DESCRIPTION
💡 What: Added a tooltip to the "Save Bookmark" button that displays the global keyboard shortcut ("⌘ K" on Mac, "Ctrl K" on Windows/Linux). Updated the keyboard event listener to trigger on either `metaKey` or `ctrlKey`.
🎯 Why: Keyboard shortcuts improve accessibility and efficiency, but they are often undiscoverable. By adding a contextual tooltip, users can easily learn the shortcut without cluttering the UI. Making the listener respect both `metaKey` and `ctrlKey` ensures cross-platform compatibility.
📸 Before/After: Screenshots were captured and verified during local testing.
♿ Accessibility: Wrapping the shortcut keys in semantic `<kbd>` tags enhances screen reader comprehension.

---
*PR created automatically by Jules for task [4489677456724342225](https://jules.google.com/task/4489677456724342225) started by @pffreitas*