### PR TITLE
🎨 Palette: Add OS-aware keyboard shortcut tooltip to New Bookmark button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-09 - Semantic Keyboard Shortcut Hints with Safe OS Detection
 **Learning:** When implementing client-side OS detection (like `navigator.platform`) for OS-specific keyboard shortcuts (e.g., ⌘ vs Ctrl) in server-side rendered applications like Next.js, doing so directly during render causes SSR hydration mismatches. Additionally, wrapping these hints in semantic `<kbd>` elements enhances both visual distinctiveness and screen reader accessibility.
 **Action:** Initialize OS state to `null` and set it inside a `useEffect` hook. Only render the shortcut hint once the OS is determined, and always wrap shortcut keys in `<kbd>` tags for accessibility.
+
+## 2024-06-09 - Cross-Platform Keyboard Shortcut Tooltips
+**Learning:** Keyboard shortcuts that exclusively check `event.metaKey` exclude Windows/Linux users, while hiding the existence of shortcuts in the UI prevents discovery. Primary actions with global shortcuts benefit significantly from conditional, OS-aware tooltip hints.
+**Action:** Always verify `(event.metaKey || event.ctrlKey)` for cross-platform support and wrap primary actions in a `TooltipProvider` with a conditionally rendered semantic `<kbd>` hint using `navigator.platform` detection.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,7 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -19,6 +20,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
@@ -76,8 +78,10 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +139,27 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent side="bottom" align="center" className="text-xs">
+              Save Bookmark <kbd className="ml-1 px-1 py-0.5 rounded-sm bg-muted text-muted-foreground font-sans">{isMac ? "⌘K" : "Ctrl+K"}</kbd>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }


### PR DESCRIPTION
💡 What: Added a tooltip to the `New Bookmark` button in `apps/web/components/bookmark/new-bookmark.tsx` that displays the keyboard shortcut for saving a bookmark (⌘K for Mac, Ctrl+K for Windows/Linux).
🎯 Why: Previously, the shortcut existed but was hidden from the user, preventing discovery. Furthermore, the event handler only checked for `event.metaKey`, meaning the shortcut did not work for Windows or Linux users who expect `Ctrl+K`. This change surfaces the feature via a helpful tooltip and ensures cross-platform compatibility by checking `event.metaKey || event.ctrlKey`.
📸 Before/After: Visual verification was performed with a Playwright script confirming the tooltip rendered correctly with the text "Save Bookmark Ctrl+K" on Linux.
♿ Accessibility: Wraps the keyboard shortcut text in semantic `<kbd>` tags for screen readers, and ensures the button is wrapped in a `TooltipProvider`. Wait for client hydration using a `useEffect` hook to prevent Server-Side Rendering (SSR) layout mismatches before conditionally rendering the OS-specific hint.

---
*PR created automatically by Jules for task [1281737797365471560](https://jules.google.com/task/1281737797365471560) started by @pffreitas*