### PR TITLE
fix: replace deprecated Grok Code Fast 1 with Qwen 3.7 Max

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",

--- a/packages/shared/src/services/bookmark.categorizer.service.ts
+++ b/packages/shared/src/services/bookmark.categorizer.service.ts
@@ -77,7 +77,7 @@ export class BookmarkCategorizerServiceImpl implements BookmarkCategorizerServic
       // Call LLM for categorization
       const response = await this.ai.generateObject({
         sessionID: session.sessionID,
-        modelId: "x-ai/grok-code-fast-1",
+        modelId: "qwen/qwen3.7-max",
         prompt,
         schema: CategorizationResponseSchema,
       });

--- a/packages/shared/src/services/bookmark.processor.service.ts
+++ b/packages/shared/src/services/bookmark.processor.service.ts
@@ -293,7 +293,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
         sessionID: session.sessionID,
         taskID: task.taskID,
         messageID: Identifier.ascending("message"),
-        modelId: "x-ai/grok-code-fast-1",
+        modelId: "qwen/qwen3.7-max",
         context: [],
         tools: [],
         message: {
@@ -437,7 +437,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
     try {
       const relevantImages = await this.ai.generateObject({
         sessionID: session.sessionID,
-        modelId: "x-ai/grok-code-fast-1",
+        modelId: "qwen/qwen3.7-max",
         prompt: FILTER_IMAGES_PROMPT.replace(
           "{{CONTENT}}",
           content.content ?? ""


### PR DESCRIPTION
## Summary

This PR replaces all instances of the deprecated `x-ai/grok-code-fast-1` model with `qwen/qwen3.7-max` to resolve bookmark creation errors.

## Changes Made

- Updated `bookmark.categorizer.service.ts` to use the new model
- Updated `bookmark.processor.service.ts` to use the new model (2 instances)
- Total of 3 model references updated

## Background

The xAI Grok Code Fast 1 model has been deprecated and xAI recommends switching to Grok 4.3 (https://openrouter.ai/x-ai/grok-4.3). However, per user preference, we're switching to `qwen/qwen3.7-max` instead.

## Testing

- [ ] Verify bookmark creation works without errors
- [ ] Verify bookmark categorization continues to function properly
- [ ] Verify bookmark processing operations complete successfully

Fixes bookmark creation errors caused by the deprecated model.