### PR TITLE
fix: use generateObject for Qwen model tag generation

### DIFF
--- a/packages/shared/src/services/bookmark.processor.service.ts
+++ b/packages/shared/src/services/bookmark.processor.service.ts
@@ -288,37 +288,21 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
     await this.eventBus.publishToBookmark(bookmark.id, "task.started", task);
 
     try {
-      let output = "";
-      for await (const part of this.ai.prompt({
+      const response = await this.ai.generateObject({
         sessionID: session.sessionID,
-        taskID: task.taskID,
-        messageID: Identifier.ascending("message"),
         modelId: "qwen/qwen3.7-max",
-        context: [],
-        tools: [],
-        message: {
-          role: "user",
-          content: GENERATE_TAGS_PROMPT.replace(
-            "{{CONTENT}}",
-            this.isTwitterBookmark(bookmark) || this.isYouTubeBookmark(bookmark)
-              ? (content.content ?? "")
-              : this.chunkingService.stripHtml(content.content ?? "")
-          ),
-        },
-      })) {
-        if (part.type === "text") {
-          output = part.part.text;
-        }
-      }
-
-      // TODO: handle error and retry
-      const parsed = z
-        .object({
+        prompt: GENERATE_TAGS_PROMPT.replace(
+          "{{CONTENT}}",
+          this.isTwitterBookmark(bookmark) || this.isYouTubeBookmark(bookmark)
+            ? (content.content ?? "")
+            : this.chunkingService.stripHtml(content.content ?? "")
+        ),
+        schema: z.object({
           tags: z.array(z.string()).describe("The array of tag strings"),
-        })
-        .parse(JSON.parse(output));
+        }),
+      });
 
-      return parsed.tags;
+      return response.tags;
     } catch (error) {
       console.error("Failed to generate metadata", error);
       await this.eventBus.publishToBookmark(bookmark.id, "task.failed", task);


### PR DESCRIPTION
## Summary

This PR fixes the JSON parsing issue introduced in PR #226 when switching from Grok Code Fast 1 to Qwen 3.7 Max.

## Problem

After switching to `qwen/qwen3.7-max`, the bookmark processor was failing with JSON parse errors:

```
SyntaxError: Unexpected token 'G', "Generated AI summary" is not valid JSON
```

The Qwen model was returning plain text responses like "Generated AI summary" instead of the required JSON format when using the streaming `prompt()` method.

## Solution

- Replace `ai.prompt()` with `ai.generateObject()` for tag generation
- Use structured schema validation with Zod
- Remove manual JSON parsing that was prone to failure
- Consistent with other parts of the codebase already using `generateObject`

## Testing

- [ ] Verify bookmark creation works without JSON parsing errors  
- [ ] Verify tag generation produces expected structured output
- [ ] Verify CI tests pass without `Failed to generate metadata` errors

## Related

- Fixes test failures from PR #226
- Addresses the root cause of bookmark processing failures with the new Qwen model