### PR TITLE
fix: stabilize backend pipeline tests

### DIFF
--- a/packages/shared/src/__tests__/integration/bookmark-content-refactor.test.ts
+++ b/packages/shared/src/__tests__/integration/bookmark-content-refactor.test.ts
@@ -112,6 +112,13 @@ describe("Bookmark Content Refactor Integration", () => {
           };
         } else if (
           input.prompt &&
+          input.prompt.includes("Your task is to generate the tags")
+        ) {
+          return {
+            tags: ["ai", "processing"],
+          };
+        } else if (
+          input.prompt &&
           input.prompt.includes("bookmark categorization assistant")
         ) {
           // Categorization prompt - suggest a new category path

--- a/packages/shared/src/__tests__/services/bookmark.processor.service.test.ts
+++ b/packages/shared/src/__tests__/services/bookmark.processor.service.test.ts
@@ -105,6 +105,13 @@ describe("BookmarkProcessorService", () => {
               },
             ],
           };
+        } else if (
+          input.prompt &&
+          input.prompt.includes("Your task is to generate the tags")
+        ) {
+          return {
+            tags: ["test", "bookmark"],
+          };
         }
         return "Default generated object";
       }),

--- a/packages/shared/src/services/bookmark.processor.service.ts
+++ b/packages/shared/src/services/bookmark.processor.service.ts
@@ -81,6 +81,8 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
       }
     );
 
+    const startedTasks: Promise<unknown>[] = [];
+
     try {
       const session = await this.ai.newSession(bookmark.id);
       await this.eventBus.publishToBookmark(
@@ -96,6 +98,12 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
         ? Promise.resolve(this.promoteTweetImages(content))
         : this.processImages(session, bookmark, content);
       const embeddingPromise = this.chunkAndEmbed(session, bookmark, content);
+      startedTasks.push(
+        summarizePromise,
+        metadataPromise,
+        imagesPromise,
+        embeddingPromise
+      );
 
       // Categorization requires summary and tags, so we wait for those first
       const [{ summary, briefSummary }, tags] = await Promise.all([
@@ -145,6 +153,12 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
         }
       );
     } catch (error) {
+      // If one parallel task fails, make sure every task that was already
+      // started has settled before rethrowing. Otherwise later rejections from
+      // the still-running tasks can surface as unhandled promise rejections in
+      // Node/Jest and fail CI after the expected error has already been caught.
+      await Promise.allSettled(startedTasks);
+
       // Update processing status to 'failed'
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";


### PR DESCRIPTION
## Summary
- Mock Qwen tag generation in backend tests now that tags use generateObject instead of prompt streaming
- Drain already-started parallel bookmark processing tasks on error to avoid unhandled promise rejections in Jest/Node

## Verification
- DATABASE_URL=<local Supabase> bun run --cwd packages/shared test -- --runInBand src/__tests__/integration/bookmark-content-refactor.test.ts src/__tests__/services/bookmark.processor.service.test.ts
- bun run --cwd packages/shared build
- bun run --cwd apps/api build
- bun run --cwd apps/worker build