### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via DNS Rebinding in HTTP client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Fastify CORS was set to `origin: true` (reflecting arbitrary origins) and the SSE endpoint manually set `Access-Control-Allow-Origin` to `request.headers.origin || "*"` while allowing credentials, risking unauthorized cross-origin access.
 **Learning:** Manual HTTP responses (like `reply.raw.writeHead` for Server-Sent Events) bypass global plugin protections like `@fastify/cors`. Developers must manually apply security headers on these raw endpoints.
 **Prevention:** Restrict CORS origins explicitly using a `FRONTEND_URL` environment variable for both global CORS plugins and manual HTTP endpoints, avoiding reflection of arbitrary request origins.
+
+## 2024-05-27 - DNS Rebinding SSRF via HTTP Clients
+**Vulnerability:** The HTTP client wrappers (like `got`) used for scraping resolved URLs without verifying if the final IP belonged to an internal or cloud metadata network (e.g., `127.0.0.1`, `169.254.169.254`).
+**Learning:** Checking hostnames or IPs before making the request is insufficient due to Time-Of-Check to Time-Of-Use (TOCTOU) DNS rebinding vulnerabilities. Attackers can configure DNS records to resolve to a benign IP during validation, but switch to an internal IP during the actual fetch.
+**Prevention:** Intercept the request at the network level (e.g., via `beforeRequest` hooks), manually resolve the DNS, validate the IP against a blocklist, and explicitly override the request's hostname to the validated IP while restoring original `Host` headers and TLS Server Name Indication (SNI).

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",

--- a/packages/shared/src/__mocks__/got.ts
+++ b/packages/shared/src/__mocks__/got.ts
@@ -1,5 +1,18 @@
 // Mock implementation of got for testing
-const mockGot = jest.fn().mockImplementation((url: string, options?: any) => {
+const mockGot = jest.fn().mockImplementation(async (url: string, options?: any) => {
+  if (options?.hooks?.beforeRequest && Array.isArray(options.hooks.beforeRequest)) {
+    // A rudimentary options object with a url object to support SSRF testing
+    const hookOptions = {
+      ...options,
+      url: new URL(url),
+      headers: options.headers || {},
+      https: options.https || {}
+    };
+    for (const hook of options.hooks.beforeRequest) {
+      await hook(hookOptions);
+    }
+  }
+
   return Promise.resolve({
     statusCode: 200,
     statusMessage: "OK",

--- a/packages/shared/src/__tests__/services/http-client.test.ts
+++ b/packages/shared/src/__tests__/services/http-client.test.ts
@@ -1,0 +1,31 @@
+import { CosmicHttpClient } from "../../services/http-client";
+
+// Ensure we are testing with the actual got library mocked to throw our hook errors
+jest.mock("got");
+
+describe("CosmicHttpClient SSRF Protections", () => {
+  let client: CosmicHttpClient;
+
+  beforeEach(() => {
+    client = new CosmicHttpClient();
+  });
+
+  it("should block requests to 127.0.0.1", async () => {
+    await expect(client.fetch("http://127.0.0.1/admin")).rejects.toThrow("SSRF attempt blocked");
+  });
+
+  it("should block requests to internal IPv4 networks", async () => {
+    await expect(client.fetch("http://10.0.0.1/secret")).rejects.toThrow("SSRF attempt blocked");
+    await expect(client.fetch("http://172.16.0.5/api")).rejects.toThrow("SSRF attempt blocked");
+    await expect(client.fetch("http://192.168.1.1/config")).rejects.toThrow("SSRF attempt blocked");
+    await expect(client.fetch("http://169.254.169.254/latest/meta-data")).rejects.toThrow("SSRF attempt blocked");
+  });
+
+  it("should block requests to IPv6 loopback", async () => {
+    await expect(client.fetch("http://[::1]/")).rejects.toThrow("SSRF attempt blocked");
+  });
+
+  it("should block requests to 0.0.0.0", async () => {
+    await expect(client.fetch("http://0.0.0.0/")).rejects.toThrow("SSRF attempt blocked");
+  });
+});

--- a/packages/shared/src/services/http-client.ts
+++ b/packages/shared/src/services/http-client.ts
@@ -1,4 +1,26 @@
+import * as net from "net";
+import * as dns from "dns";
 const got = require("got").default || require("got");
+
+function isInternalIP(ip: string): boolean {
+  if (ip === "0.0.0.0") return true;
+  if (ip.startsWith("127.")) return true;
+  if (ip.startsWith("10.")) return true;
+  if (ip.startsWith("192.168.")) return true;
+  if (ip.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\./)) return true;
+  if (ip.startsWith("169.254.")) return true; // Cloud instance metadata
+
+  if (net.isIPv6(ip)) {
+    const ipv6 = ip.toLowerCase();
+    if (ipv6 === "::1" || ipv6 === "::") return true;
+    if (ipv6.startsWith("fc") || ipv6.startsWith("fd") || ipv6.startsWith("fe8")) return true;
+    if (ipv6.startsWith("::ffff:")) {
+      const ipv4 = ipv6.substring(7);
+      return isInternalIP(ipv4);
+    }
+  }
+  return false;
+}
 
 export interface HttpClient {
   /**
@@ -70,10 +92,35 @@ export class CosmicHttpClient implements HttpClient {
         throwHttpErrors: true,
         hooks: {
           beforeRequest: [
-            (options: any) => {
+            async (options: any) => {
               console.log(
                 `🌐 Making request to ${options.url} (attempt ${options.retryCount || 1})`
               );
+              const hostname = options.url.hostname;
+              const rawHostname = hostname.replace(/^\[(.*)\]$/, "$1");
+
+              let ip = rawHostname;
+              if (!net.isIP(rawHostname)) {
+                try {
+                  const result = await dns.promises.lookup(rawHostname);
+                  ip = result.address;
+                } catch (err) {
+                  throw new Error(`DNS lookup failed for ${rawHostname}`);
+                }
+              }
+
+              if (isInternalIP(ip)) {
+                throw new Error("SSRF attempt blocked: Internal IP address detected");
+              }
+
+              options.url.hostname = net.isIPv6(ip) ? `[${ip}]` : ip;
+              options.headers = options.headers || {};
+              options.headers.Host = hostname;
+
+              if (!net.isIP(rawHostname)) {
+                options.https = options.https || {};
+                options.https.servername = hostname;
+              }
             },
           ],
           afterResponse: [


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) exists in the web scraping functionality due to missing validation on requested URLs. Attackers could theoretically access internal network resources, local services, or cloud instance metadata.
🎯 Impact: An attacker could bypass external firewalls, extract cloud credentials from `169.254.169.254`, or scan internal networks by providing crafted URLs for scraping.
🔧 Fix: Implemented an IP blocklist in the `CosmicHttpClient` by injecting a `beforeRequest` hook into the `got` library. It performs a proactive DNS resolution, checks the resolved IP against internal/loopback/cloud ranges, and pins the request to the resolved IP to prevent Time-Of-Check to Time-Of-Use (TOCTOU) DNS rebinding attacks while explicitly setting TLS `servername` and `Host` headers to avoid regressions.
✅ Verification: Covered by unit tests mimicking malicious requests to internal ranges. Ensure `bun test` passes in `packages/shared`.

---
*PR created automatically by Jules for task [12079528263453318973](https://jules.google.com/task/12079528263453318973) started by @pffreitas*