### PR TITLE
🎨 Palette: Add tooltip and cross-platform support for save bookmark shortcut

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-05-03 - Added ARIA labels to Profile Dropdown Buttons
 **Learning:** Avatar-based profile menu triggers are often missing accessible names, leading to silent or confusing screen reader announcements.
 **Action:** Add `aria-label="Open profile menu"` to any icon-only or avatar-only dropdown triggers to improve keyboard and screen reader accessibility.
+
+## 2024-06-13 - Cross-Platform Keyboard Shortcuts
+**Learning:** Hardcoding `event.metaKey` for keyboard shortcuts excludes Windows/Linux users. Tooltips for global action shortcuts (`Cmd+K`/`Ctrl+K`) drastically improve feature discovery. Conditionally rendering the OS-specific hint (`isMac`) requires initializing to `null` and updating in `useEffect` to prevent React hydration errors.
+**Action:** Always check `event.metaKey || event.ctrlKey` for cross-platform support. Ensure global action buttons display their shortcut in an accessible tooltip (`TooltipProvider` + `<kbd>`).

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -19,6 +25,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
@@ -76,8 +83,12 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   };
 
   useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +146,35 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent side="bottom" className="flex items-center gap-1.5 py-1.5">
+              <span>Save Bookmark</span>
+              <span className="flex items-center gap-0.5 text-[10px] text-primary-foreground/80 font-medium">
+                <kbd className="font-sans bg-primary-foreground/20 px-1 py-0.5 rounded">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans bg-primary-foreground/20 px-1 py-0.5 rounded">
+                  K
+                </kbd>
+              </span>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
* 💡 What: Added cross-platform support (`Ctrl + K`) and a tooltip hint for the "Save Bookmark" button's keyboard shortcut.
* 🎯 Why: Users on Windows and Linux could not use the existing `Cmd + K` shortcut, and all users had no visual way to discover the shortcut existed without reading documentation.
* ♿ Accessibility: Improved keyboard accessibility across operating systems and enhanced discoverability with an accessible semantic `<kbd>` tooltip.

---
*PR created automatically by Jules for task [10357175477159704440](https://jules.google.com/task/10357175477159704440) started by @pffreitas*