### PR TITLE
🎨 Palette: Improve New Bookmark Keyboard Shortcut Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-05-03 - Added ARIA labels to Profile Dropdown Buttons
 **Learning:** Avatar-based profile menu triggers are often missing accessible names, leading to silent or confusing screen reader announcements.
 **Action:** Add `aria-label="Open profile menu"` to any icon-only or avatar-only dropdown triggers to improve keyboard and screen reader accessibility.
+## 2025-01-01 - Added Tooltip Hint for Keyboard Shortcut
+**Learning:** Keyboard shortcuts that only rely on `metaKey` (Mac) alienate Windows/Linux users, and hidden shortcuts have poor discoverability.
+**Action:** When implementing global shortcuts, check both `metaKey` and `ctrlKey`, and expose the shortcut visually in the UI (e.g., via a Tooltip on the primary action button) showing the OS-appropriate modifier key to improve accessibility.

--- a/apps/web/components/bookmark/new-bookmark.tsx
+++ b/apps/web/components/bookmark/new-bookmark.tsx
@@ -11,6 +11,12 @@ import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { Bookmark } from "lucide-react";
 import { PreviewResponse } from "@cosmic-dolphin/api-client";
 import PrivateLinkDialog from "./private-link-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface NewBookmarkButtonProps {}
 
@@ -19,6 +25,11 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
   const [url, setUrl] = useState("");
   const [privateLinkDialogOpen, setPrivateLinkDialogOpen] = useState(false);
   const [previewData, setPreviewData] = useState<PreviewResponse | null>(null);
+  const [isMac, setIsMac] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0);
+  }, []);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const createLoading = useAppSelector(
@@ -77,7 +88,7 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
         handleNewBookmark();
       }
@@ -135,16 +146,35 @@ export default function NewBookmarkButton({}: NewBookmarkButtonProps) {
         />
       )}
 
-      <button
-        id="new-bookmark-button"
-        className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
-        onClick={() => {
-          handleNewBookmark();
-        }}
-      >
-        <Bookmark size={16} />
-        Save Bookmark
-      </button>
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              id="new-bookmark-button"
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-noto text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              onClick={() => {
+                handleNewBookmark();
+              }}
+            >
+              <Bookmark size={16} />
+              Save Bookmark
+            </button>
+          </TooltipTrigger>
+          {isMac !== null && (
+            <TooltipContent side="bottom">
+              <p className="flex items-center gap-1">
+                New bookmark{" "}
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200 text-black">
+                  {isMac ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="font-sans px-1.5 py-0.5 rounded-md border bg-gray-50 border-gray-200 text-black">
+                  K
+                </kbd>
+              </p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosmic-dolphin",


### PR DESCRIPTION
💡 What:
- Updated the "New Bookmark" keyboard shortcut handler to check for both `metaKey` and `ctrlKey`.
- Wrapped the "New Bookmark" button in a `TooltipProvider` and added an OS-specific tooltip hint displaying either "⌘ K" (Mac) or "Ctrl K" (Windows/Linux).

🎯 Why:
- Previous implementation only checked `metaKey`, making the shortcut inaccessible to Windows/Linux users.
- The global shortcut had no visual indicator, meaning users would only discover it by accident. Surfacing the keyboard hint improves learnability.

♿ Accessibility:
- The tooltip provides a visual cue for keyboard navigation.
- Broadened shortcut support directly improves accessibility across all operating systems.

---
*PR created automatically by Jules for task [13308738895823896606](https://jules.google.com/task/13308738895823896606) started by @pffreitas*