### PR TITLE
Refactor bookmark AI model IDs into shared constants

### DIFF
--- a/packages/shared/src/__tests__/services/bookmark.processor.service.test.ts
+++ b/packages/shared/src/__tests__/services/bookmark.processor.service.test.ts
@@ -333,6 +333,53 @@ describe("BookmarkProcessorService", () => {
       );
     });
 
+    it("uses the large model for full summaries and the small model for generated bookmark data", async () => {
+      const mockSession: Session = {
+        sessionID: "test-session-id",
+        refID: testBookmark.id,
+      };
+
+      const mockTask: Task = {
+        taskID: "test-task-id",
+        sessionID: mockSession.sessionID,
+        name: "test-task",
+        status: "pending",
+        subTasks: {},
+      };
+
+      mockBookmarkService.findByIdAndUser.mockResolvedValue(testBookmark);
+      mockBookmarkService.getScrapedUrlContent.mockResolvedValue(
+        testScrapedContent
+      );
+      mockBookmarkService.updateProcessingStatus.mockResolvedValue(
+        testBookmark
+      );
+      mockBookmarkService.update.mockResolvedValue(testBookmark);
+      mockAI.newSession.mockResolvedValue(mockSession);
+      mockAI.newTask.mockResolvedValue(mockTask);
+      mockAI.newSubTask.mockResolvedValue({
+        taskID: "subtask-id",
+        name: "test-subtask",
+        status: "pending",
+      });
+
+      await service.process(testBookmark.id, testBookmark.userId);
+
+      expect(mockAI.prompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: "qwen/qwen3.7-plus",
+        })
+      );
+      expect(
+        mockAI.generateObject.mock.calls.map(([input]) => input.modelId)
+      ).toEqual([
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash",
+      ]);
+    });
+
     it("should handle AI processing errors gracefully", async () => {
       const mockSession: Session = {
         sessionID: "test-session-id",

--- a/packages/shared/src/__tests__/services/bookmark.service.test.ts
+++ b/packages/shared/src/__tests__/services/bookmark.service.test.ts
@@ -4,6 +4,7 @@ import { BookmarkRepository } from "../../repositories";
 import { WebScrapingService } from "../../services/web-scraping.service";
 import { TestDataFactory } from "../../test-utils/factories";
 import { ScrapedUrlContents } from "../../types";
+import { AI } from "../../ai";
 
 describe("BookmarkService", () => {
   let service: BookmarkServiceImpl;
@@ -185,6 +186,35 @@ describe("BookmarkService", () => {
       await expect(
         service.delete("test-bookmark-id", testUserId)
       ).rejects.toThrow(TypeError);
+    });
+  });
+
+  describe("inferPrivateLinkMetadata", () => {
+    it("uses the small model for private link inference", async () => {
+      const mockAI = {
+        generateObject: jest.fn<any>().mockResolvedValue({
+          description: "A private design file.",
+          tags: ["design", "private-link"],
+        }),
+      } as unknown as jest.Mocked<AI>;
+      const serviceWithAI = new BookmarkServiceImpl(
+        mockRepository,
+        mockWebScrapingService,
+        undefined,
+        mockAI
+      );
+
+      await serviceWithAI.inferPrivateLinkMetadata(
+        "https://figma.com/file/example",
+        "Design file",
+        "Figma"
+      );
+
+      expect(mockAI.generateObject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: "deepseek/deepseek-v4-flash",
+        })
+      );
     });
   });
 });

--- a/packages/shared/src/services/bookmark.categorizer.service.ts
+++ b/packages/shared/src/services/bookmark.categorizer.service.ts
@@ -9,6 +9,7 @@ import {
   buildCategoryTreeText,
   buildCategorizationPrompt,
 } from "./bookmark.categorizer.prompt";
+import { BOOKMARK_MODEL_IDS } from "./bookmark.model-ids";
 
 // Zod schema for LLM response validation
 export const CategorizationResponseSchema = z.object({
@@ -77,7 +78,7 @@ export class BookmarkCategorizerServiceImpl implements BookmarkCategorizerServic
       // Call LLM for categorization
       const response = await this.ai.generateObject({
         sessionID: session.sessionID,
-        modelId: "qwen/qwen3.7-max",
+        modelId: BOOKMARK_MODEL_IDS.small,
         prompt,
         schema: CategorizationResponseSchema,
       });

--- a/packages/shared/src/services/bookmark.model-ids.ts
+++ b/packages/shared/src/services/bookmark.model-ids.ts
@@ -1,0 +1,6 @@
+export const BOOKMARK_MODEL_IDS = {
+  large: "qwen/qwen3.7-plus",
+  small: "deepseek/deepseek-v4-flash",
+} as const;
+
+export type BookmarkModelCategory = keyof typeof BOOKMARK_MODEL_IDS;

--- a/packages/shared/src/services/bookmark.processor.service.ts
+++ b/packages/shared/src/services/bookmark.processor.service.ts
@@ -24,6 +24,7 @@ import {
 import { CollectionRepository } from "../repositories/collection.repository";
 import { ChunkingService, ChunkingServiceImpl } from "./chunking.service";
 import { EmbeddingService, EmbeddingServiceImpl } from "./embedding.service";
+import { BOOKMARK_MODEL_IDS } from "./bookmark.model-ids";
 
 export interface BookmarkProcessorService {
   process(id: string, userId: string): Promise<void>;
@@ -242,7 +243,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
         sessionID: session.sessionID,
         taskID: task.taskID,
         messageID: Identifier.ascending("message"),
-        modelId: "google/gemini-2.5-pro",
+        modelId: BOOKMARK_MODEL_IDS.large,
         context: [],
         tools: [],
         message: {
@@ -268,7 +269,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
 
       briefSummary = await this.ai.generateObject({
         sessionID: session.sessionID,
-        modelId: "google/gemini-2.5-flash",
+        modelId: BOOKMARK_MODEL_IDS.small,
         prompt: briefPrompt.replace("{{CONTENT}}", textContent),
         schema: z.string().describe("The summary of the content"),
       });
@@ -304,7 +305,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
     try {
       const response = await this.ai.generateObject({
         sessionID: session.sessionID,
-        modelId: "qwen/qwen3.7-max",
+        modelId: BOOKMARK_MODEL_IDS.small,
         prompt: GENERATE_TAGS_PROMPT.replace(
           "{{CONTENT}}",
           this.isTwitterBookmark(bookmark) || this.isYouTubeBookmark(bookmark)
@@ -435,7 +436,7 @@ export class BookmarkProcessorServiceImpl implements BookmarkProcessorService {
     try {
       const relevantImages = await this.ai.generateObject({
         sessionID: session.sessionID,
-        modelId: "qwen/qwen3.7-max",
+        modelId: BOOKMARK_MODEL_IDS.small,
         prompt: FILTER_IMAGES_PROMPT.replace(
           "{{CONTENT}}",
           content.content ?? ""

--- a/packages/shared/src/services/bookmark.service.ts
+++ b/packages/shared/src/services/bookmark.service.ts
@@ -17,6 +17,7 @@ import { WebScrapingService } from "./web-scraping.service";
 import { NewBookmark, BookmarkUpdate } from "../database/schema";
 import { AI } from "../ai";
 import { z } from "zod";
+import { BOOKMARK_MODEL_IDS } from "./bookmark.model-ids";
 
 export interface PrivateLinkMetadata {
   title?: string;
@@ -178,7 +179,7 @@ export class BookmarkServiceImpl implements BookmarkService {
 
     const result = await this.ai.generateObject({
       sessionID: "private-link-inference",
-      modelId: "google/gemini-2.5-flash",
+      modelId: BOOKMARK_MODEL_IDS.small,
       prompt,
       schema: z.object({
         description: z.string().describe("Brief description of the link"),

--- a/packages/shared/src/services/index.ts
+++ b/packages/shared/src/services/index.ts
@@ -7,6 +7,7 @@ export * from "./collection.service";
 export * from "./profile.service";
 export * from "./bookmark.processor.service";
 export * from "./bookmark.categorizer.service";
+export * from "./bookmark.model-ids";
 export * from "./chunking.service";
 export * from "./embedding.service";
 export * from "./search.service";


### PR DESCRIPTION
## Summary
- Centralize bookmark AI model IDs in a shared `BOOKMARK_MODEL_IDS` constant
- Use the small model for categorization, tag generation, image filtering, and private link inference
- Keep the large model for full bookmark summaries
- Add tests covering model selection in processor and private link inference flows

## Testing
- Unit tests added for bookmark processor and bookmark service model selection