### PR TITLE
Add offline bookmark caching to mobile bookmarks

### DIFF
--- a/apps/mobile/app/bookmark/[id].tsx
+++ b/apps/mobile/app/bookmark/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import {
   StyleSheet,
   View,
@@ -19,6 +19,13 @@ import { Ionicons } from '@expo/vector-icons';
 import Markdown from 'react-native-markdown-display';
 
 import { Bookmark, BookmarksAPI } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  cacheBookmarksInBackground,
+  getCachedBookmark,
+  removeCachedBookmark,
+} from '@/lib/bookmark-cache';
+import { isAuthError } from '@/lib/api-errors';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
@@ -47,6 +54,7 @@ function formatDate(dateString: string): string {
 export default function BookmarkDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const { user } = useAuth();
   const colorScheme = useColorScheme() ?? 'light';
   const colors = Colors[colorScheme];
 
@@ -167,33 +175,50 @@ export default function BookmarkDetailScreen() {
     },
   }), [colors]);
 
-  useEffect(() => {
-    if (id) {
-      fetchBookmark(id);
-    }
-  }, [id]);
+  const applyBookmark = useCallback((data: Bookmark) => {
+    setBookmark(data);
+    setIsLiked(data.isLikedByCurrentUser ?? false);
+    setLikeCount(data.likeCount ?? 0);
+    setIsShared(data.isPublic ?? false);
+  }, []);
 
-  const fetchBookmark = async (bookmarkId: string) => {
+  const fetchBookmark = useCallback(async (bookmarkId: string) => {
     setIsLoading(true);
     setError(null);
 
     try {
       const data = await BookmarksAPI.findById(bookmarkId);
       if (data) {
-        setBookmark(data);
-        setIsLiked(data.isLikedByCurrentUser ?? false);
-        setLikeCount(data.likeCount ?? 0);
-        setIsShared(data.isPublic ?? false);
+        applyBookmark(data);
+        cacheBookmarksInBackground(user?.id, [data]);
       } else {
+        if (user?.id) {
+          await removeCachedBookmark(user.id, bookmarkId);
+        }
         setError('Bookmark not found');
       }
     } catch (err) {
+      if (user?.id && !isAuthError(err)) {
+        const cachedBookmark = await getCachedBookmark(user.id, bookmarkId);
+        if (cachedBookmark) {
+          applyBookmark(cachedBookmark);
+          setError(null);
+          return;
+        }
+      }
+
       console.error('Error fetching bookmark:', err);
       setError(err instanceof Error ? err.message : 'Failed to load bookmark');
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [applyBookmark, user?.id]);
+
+  useEffect(() => {
+    if (id) {
+      fetchBookmark(id);
+    }
+  }, [fetchBookmark, id]);
 
   const handleOpenUrl = () => {
     if (bookmark?.sourceUrl) {
@@ -250,7 +275,7 @@ export default function BookmarkDetailScreen() {
       setIsShared(result.isPublic);
       setShareUrl(result.shareUrl);
       setIsShareModalVisible(true);
-    } catch (err) {
+    } catch {
       Alert.alert('Error', 'Failed to share bookmark. Please try again.');
     } finally {
       setIsShareLoading(false);
@@ -266,7 +291,7 @@ export default function BookmarkDetailScreen() {
       setIsShared(result.isPublic);
       setShareUrl('');
       setIsShareModalVisible(false);
-    } catch (err) {
+    } catch {
       Alert.alert('Error', 'Failed to unshare bookmark. Please try again.');
     } finally {
       setIsShareLoading(false);

--- a/apps/mobile/app/bookmark/__tests__/[id].test.tsx
+++ b/apps/mobile/app/bookmark/__tests__/[id].test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { act, render, fireEvent, waitFor } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import BookmarkDetailScreen from '../[id]';
 import { BookmarksAPI } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  cacheBookmarksInBackground,
+  getCachedBookmark,
+  removeCachedBookmark,
+} from '@/lib/bookmark-cache';
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ id: '123' }),
@@ -15,6 +21,16 @@ jest.mock('@/lib/api', () => ({
     like: jest.fn(),
     unlike: jest.fn(),
   },
+}));
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/bookmark-cache', () => ({
+  cacheBookmarksInBackground: jest.fn(),
+  getCachedBookmark: jest.fn(),
+  removeCachedBookmark: jest.fn(),
 }));
 
 jest.mock('react-native-markdown-display', () => {
@@ -31,9 +47,13 @@ describe('BookmarkDetailScreen Like Functionality', () => {
     title: 'Test Bookmark',
     sourceUrl: 'https://example.com',
     createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
     userId: 'user-1',
     likeCount: 5,
     isLikedByCurrentUser: false,
+    isPrivateLink: false,
+    isPublic: false,
+    processingStatus: 'completed',
     metadata: {
       openGraph: {
         siteName: 'Example',
@@ -50,33 +70,94 @@ describe('BookmarkDetailScreen Like Functionality', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: 'user-1' },
+    });
+    (getCachedBookmark as jest.Mock).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('renders like button with correct count', async () => {
     (BookmarksAPI.findById as jest.Mock).mockResolvedValue(mockBookmark);
 
-    const { getByText, findByTestId } = render(<BookmarkDetailScreen />);
+    const { getByText, getByTestId } = render(<BookmarkDetailScreen />);
 
-    // Wait for the button to appear
-    const likeButton = await findByTestId('like-button');
+    await waitFor(() => {
+      expect(getByTestId('like-button')).toBeTruthy();
+      expect(getByText('5')).toBeTruthy();
+    });
+  });
 
-    expect(likeButton).toBeTruthy();
-    expect(getByText('5')).toBeTruthy();
+  it('caches online bookmark details in the background', async () => {
+    (BookmarksAPI.findById as jest.Mock).mockResolvedValue(mockBookmark);
+
+    const { getByText } = render(<BookmarkDetailScreen />);
+
+    await waitFor(() => expect(getByText('Test Bookmark')).toBeTruthy());
+
+    expect(cacheBookmarksInBackground).toHaveBeenCalledWith('user-1', [mockBookmark]);
+  });
+
+  it('renders cached bookmark details when the online fetch fails', async () => {
+    const cachedBookmark = {
+      ...mockBookmark,
+      title: 'Offline Bookmark',
+    };
+    (BookmarksAPI.findById as jest.Mock).mockRejectedValue(new Error('Network error'));
+    (getCachedBookmark as jest.Mock).mockResolvedValue(cachedBookmark);
+
+    const { getByText, queryByText } = render(<BookmarkDetailScreen />);
+
+    await waitFor(() => expect(getByText('Offline Bookmark')).toBeTruthy());
+
+    expect(queryByText('Something went wrong')).toBeNull();
+  });
+
+  it('does not render cached bookmark details when the online fetch fails with an auth error', async () => {
+    const authError = Object.assign(new Error('HTTP error! status: 401'), {
+      status: 401,
+    });
+    (BookmarksAPI.findById as jest.Mock).mockRejectedValue(authError);
+    (getCachedBookmark as jest.Mock).mockResolvedValue({
+      ...mockBookmark,
+      title: 'Offline Bookmark',
+    });
+
+    const { getByText, queryByText } = render(<BookmarkDetailScreen />);
+
+    await waitFor(() => expect(getByText('HTTP error! status: 401')).toBeTruthy());
+
+    expect(queryByText('Offline Bookmark')).toBeNull();
+  });
+
+  it('removes cached details when the bookmark no longer exists online', async () => {
+    (BookmarksAPI.findById as jest.Mock).mockResolvedValue(null);
+
+    const { getByText } = render(<BookmarkDetailScreen />);
+
+    await waitFor(() => expect(getByText('Bookmark not found')).toBeTruthy());
+
+    expect(removeCachedBookmark).toHaveBeenCalledWith('user-1', '123');
   });
 
   it('optimistically increments like count and calls like API', async () => {
     (BookmarksAPI.findById as jest.Mock).mockResolvedValue(mockBookmark);
     (BookmarksAPI.like as jest.Mock).mockResolvedValue({ likeCount: 6, isLikedByCurrentUser: true });
 
-    const { getByText, getByTestId, findByTestId } = render(<BookmarkDetailScreen />);
+    const { getByText, findByTestId } = render(<BookmarkDetailScreen />);
 
     const likeButton = await findByTestId('like-button');
     expect(getByText('5')).toBeTruthy();
 
-    fireEvent.press(likeButton);
+    await act(async () => {
+      fireEvent.press(likeButton);
+    });
 
-    // Optimistically changed to 6
     expect(getByText('6')).toBeTruthy();
     expect(BookmarksAPI.like).toHaveBeenCalledWith('123');
 
@@ -88,14 +169,15 @@ describe('BookmarkDetailScreen Like Functionality', () => {
     (BookmarksAPI.findById as jest.Mock).mockResolvedValue(mockLikedBookmark);
     (BookmarksAPI.unlike as jest.Mock).mockResolvedValue({ likeCount: 5, isLikedByCurrentUser: false });
 
-    const { getByText, getByTestId, findByTestId } = render(<BookmarkDetailScreen />);
+    const { getByText, findByTestId } = render(<BookmarkDetailScreen />);
 
     const likeButton = await findByTestId('like-button');
     expect(getByText('6')).toBeTruthy();
 
-    fireEvent.press(likeButton);
+    await act(async () => {
+      fireEvent.press(likeButton);
+    });
 
-    // Optimistically changed to 5
     expect(getByText('5')).toBeTruthy();
     expect(BookmarksAPI.unlike).toHaveBeenCalledWith('123');
   });
@@ -104,15 +186,14 @@ describe('BookmarkDetailScreen Like Functionality', () => {
     (BookmarksAPI.findById as jest.Mock).mockResolvedValue(mockBookmark);
     (BookmarksAPI.like as jest.Mock).mockRejectedValue(new Error('Network error'));
 
-    const { getByText, getByTestId, findByTestId } = render(<BookmarkDetailScreen />);
+    const { getByText, findByTestId } = render(<BookmarkDetailScreen />);
 
     const likeButton = await findByTestId('like-button');
     expect(getByText('5')).toBeTruthy();
 
-    fireEvent.press(likeButton);
-
-    // Optimistically changed to 6
-    expect(getByText('6')).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(likeButton);
+    });
 
     await waitFor(() => {
       // Reverted to 5

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import * as QueryParams from 'expo-auth-session/build/QueryParams';
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
 import { Alert, Platform } from 'react-native';
+import { clearBookmarkCache } from '@/lib/bookmark-cache';
 
 // Required for web only
 WebBrowser.maybeCompleteAuthSession();
@@ -208,8 +209,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Sign out
   const signOut = async () => {
     try {
+      const signedInUserId = user?.id;
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
+
+      if (signedInUserId) {
+        await clearBookmarkCache(signedInUserId);
+      }
     } catch (error: any) {
       console.error('Sign out error:', error);
       Alert.alert('Sign Out Error', error.message || 'Failed to sign out');

--- a/apps/mobile/contexts/__tests__/AuthContext.test.tsx
+++ b/apps/mobile/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+
+import { AuthProvider, useAuth } from '../AuthContext';
+import { supabase } from '@/lib/supabase';
+import { clearBookmarkCache } from '@/lib/bookmark-cache';
+
+jest.mock('@/lib/bookmark-cache', () => ({
+  clearBookmarkCache: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+      onAuthStateChange: jest.fn(),
+      signOut: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('expo-auth-session', () => ({
+  makeRedirectUri: jest.fn(() => 'cosmicdolphin://auth/callback'),
+}));
+
+jest.mock('expo-auth-session/build/QueryParams', () => ({
+  getQueryParams: jest.fn(() => ({ params: {}, errorCode: null })),
+}));
+
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: jest.fn(),
+  openAuthSessionAsync: jest.fn(),
+}));
+
+jest.mock('expo-linking', () => ({
+  addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  getInitialURL: jest.fn(() => Promise.resolve(null)),
+}));
+
+const userId = 'user-1';
+
+function CaptureAuth({ onValue }: { onValue: (value: ReturnType<typeof useAuth>) => void }) {
+  const auth = useAuth();
+  onValue(auth);
+  return null;
+}
+
+describe('AuthProvider cache cleanup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: {
+        session: {
+          user: {
+            id: userId,
+            email: 'user@example.com',
+          },
+        },
+      },
+      error: null,
+    });
+    (supabase.auth.onAuthStateChange as jest.Mock).mockReturnValue({
+      data: {
+        subscription: {
+          unsubscribe: jest.fn(),
+        },
+      },
+    });
+    (supabase.auth.signOut as jest.Mock).mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clears the signed-in user bookmark cache after sign out', async () => {
+    let authValue: ReturnType<typeof useAuth> | undefined;
+
+    render(
+      <AuthProvider>
+        <CaptureAuth onValue={(value) => { authValue = value; }} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(authValue?.isLoading).toBe(false));
+
+    await act(async () => {
+      await authValue!.signOut();
+    });
+
+    expect(supabase.auth.signOut).toHaveBeenCalled();
+    expect(clearBookmarkCache).toHaveBeenCalledWith(userId);
+  });
+});

--- a/apps/mobile/hooks/__tests__/useAISearch.test.tsx
+++ b/apps/mobile/hooks/__tests__/useAISearch.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { HybridSearchResultItem, SearchAPI, Bookmark } from '@/lib/api';
+import { cacheBookmarksInBackground } from '@/lib/bookmark-cache';
+import { useAISearch } from '../useAISearch';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/api', () => ({
+  SearchAPI: {
+    askWithStream: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/bookmark-cache', () => ({
+  cacheBookmarksInBackground: jest.fn(),
+}));
+
+const userId = 'user-1';
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: 'bookmark-1',
+    sourceUrl: 'https://example.com/article',
+    title: 'AI Result Article',
+    userId,
+    createdAt: '2026-06-01T12:00:00.000Z',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    isPrivateLink: false,
+    isPublic: false,
+    processingStatus: 'completed',
+    ...overrides,
+  };
+}
+
+describe('useAISearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: userId },
+    });
+  });
+
+  it('returns streamed search results and caches their bookmarks in the background', async () => {
+    const bookmark = makeBookmark();
+    const searchResult: HybridSearchResultItem = {
+      bookmark,
+      score: 0.9,
+      matchedChunks: ['matched text'],
+    };
+
+    (SearchAPI.askWithStream as jest.Mock).mockImplementation(async (_query, callbacks) => {
+      callbacks.onResults([searchResult]);
+      callbacks.onDone();
+    });
+
+    const { result } = renderHook(() => useAISearch());
+
+    act(() => {
+      result.current.executeSearch('article');
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    expect(result.current.results).toEqual([searchResult]);
+    expect(cacheBookmarksInBackground).toHaveBeenCalledWith(userId, [bookmark]);
+  });
+});

--- a/apps/mobile/hooks/__tests__/useBookmarks.test.tsx
+++ b/apps/mobile/hooks/__tests__/useBookmarks.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { BookmarksAPI, Bookmark } from '@/lib/api';
+import {
+  cacheLibraryPageInBackground,
+  getCachedLibrary,
+} from '@/lib/bookmark-cache';
+import { useBookmarks } from '../useBookmarks';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/api', () => ({
+  BookmarksAPI: {
+    list: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/bookmark-cache', () => ({
+  cacheLibraryPageInBackground: jest.fn(),
+  getCachedLibrary: jest.fn(),
+}));
+
+const userId = 'user-1';
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: 'bookmark-1',
+    sourceUrl: 'https://example.com/article',
+    title: 'Library Article',
+    userId,
+    createdAt: '2026-06-01T12:00:00.000Z',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    isPrivateLink: false,
+    isPublic: false,
+    processingStatus: 'completed',
+    ...overrides,
+  };
+}
+
+describe('useBookmarks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: userId },
+    });
+    (getCachedLibrary as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('renders online bookmarks and caches the refreshed page in the background', async () => {
+    const bookmark = makeBookmark();
+    (BookmarksAPI.list as jest.Mock).mockResolvedValue([bookmark]);
+
+    const { result } = renderHook(() => useBookmarks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.bookmarks).toEqual([bookmark]);
+    expect(result.current.isOffline).toBe(false);
+    expect(cacheLibraryPageInBackground).toHaveBeenCalledWith(userId, [bookmark], {
+      reset: true,
+    });
+  });
+
+  it('serves cached bookmarks when the initial online fetch fails', async () => {
+    const cachedBookmark = makeBookmark({ title: 'Offline Article' });
+    (BookmarksAPI.list as jest.Mock).mockRejectedValue(new Error('Network error'));
+    (getCachedLibrary as jest.Mock).mockResolvedValue([cachedBookmark]);
+
+    const { result } = renderHook(() => useBookmarks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.bookmarks).toEqual([cachedBookmark]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isOffline).toBe(true);
+  });
+
+  it('returns an error when online fetch fails and no cached bookmarks exist', async () => {
+    (BookmarksAPI.list as jest.Mock).mockRejectedValue(new Error('Network error'));
+    (getCachedLibrary as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useBookmarks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.bookmarks).toEqual([]);
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.isOffline).toBe(false);
+  });
+
+  it('does not serve cached bookmarks when the online fetch fails with an auth error', async () => {
+    const cachedBookmark = makeBookmark({ title: 'Offline Article' });
+    const authError = Object.assign(new Error('HTTP error! status: 401'), {
+      status: 401,
+    });
+    (BookmarksAPI.list as jest.Mock).mockRejectedValue(authError);
+    (getCachedLibrary as jest.Mock).mockResolvedValue([cachedBookmark]);
+
+    const { result } = renderHook(() => useBookmarks());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.bookmarks).toEqual([]);
+    expect(result.current.error).toBe('HTTP error! status: 401');
+    expect(result.current.isOffline).toBe(false);
+  });
+});

--- a/apps/mobile/hooks/__tests__/useSearch.test.tsx
+++ b/apps/mobile/hooks/__tests__/useSearch.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { BookmarksAPI, Bookmark } from '@/lib/api';
+import { cacheBookmarksInBackground } from '@/lib/bookmark-cache';
+import { useSearch } from '../useSearch';
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/api', () => ({
+  BookmarksAPI: {
+    search: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/bookmark-cache', () => ({
+  cacheBookmarksInBackground: jest.fn(),
+}));
+
+const userId = 'user-1';
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: 'bookmark-1',
+    sourceUrl: 'https://example.com/article',
+    title: 'Search Article',
+    userId,
+    createdAt: '2026-06-01T12:00:00.000Z',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    isPrivateLink: false,
+    isPublic: false,
+    processingStatus: 'completed',
+    ...overrides,
+  };
+}
+
+describe('useSearch', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: userId },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns online search results and caches them in the background', async () => {
+    const bookmark = makeBookmark();
+    (BookmarksAPI.search as jest.Mock).mockResolvedValue([bookmark]);
+
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setQuery('article');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(result.current.results).toEqual([bookmark]));
+    expect(cacheBookmarksInBackground).toHaveBeenCalledWith(userId, [bookmark]);
+  });
+});

--- a/apps/mobile/hooks/useAISearch.ts
+++ b/apps/mobile/hooks/useAISearch.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { SearchAPI, HybridSearchResultItem } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { cacheBookmarksInBackground } from '@/lib/bookmark-cache';
 
 interface UseAISearchResult {
   results: HybridSearchResultItem[];
@@ -13,6 +15,7 @@ interface UseAISearchResult {
 }
 
 export function useAISearch(): UseAISearchResult {
+  const { user } = useAuth();
   const [results, setResults] = useState<HybridSearchResultItem[]>([]);
   const [aiResponse, setAiResponse] = useState('');
   const [isSearching, setIsSearching] = useState(false);
@@ -44,6 +47,10 @@ export function useAISearch(): UseAISearchResult {
       onResults: (searchResults) => {
         if (!abortRef.current) {
           setResults(searchResults);
+          cacheBookmarksInBackground(
+            user?.id,
+            searchResults.map((result) => result.bookmark)
+          );
           setIsSearching(false);
         }
       },
@@ -72,7 +79,7 @@ export function useAISearch(): UseAISearchResult {
         setIsStreaming(false);
       }
     });
-  }, []);
+  }, [user?.id]);
 
   return {
     results,

--- a/apps/mobile/hooks/useBookmarks.ts
+++ b/apps/mobile/hooks/useBookmarks.ts
@@ -1,5 +1,11 @@
 import { useState, useCallback, useEffect } from 'react';
 import { BookmarksAPI, Bookmark } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  cacheLibraryPageInBackground,
+  getCachedLibrary,
+} from '@/lib/bookmark-cache';
+import { isAuthError } from '@/lib/api-errors';
 
 const PAGE_SIZE = 20;
 
@@ -8,20 +14,34 @@ interface UseBookmarksResult {
   isLoading: boolean;
   isLoadingMore: boolean;
   error: string | null;
+  isOffline: boolean;
   hasMore: boolean;
   refresh: () => Promise<void>;
   loadMore: () => Promise<void>;
 }
 
 export function useBookmarks(): UseBookmarksResult {
+  const { user } = useAuth();
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isOffline, setIsOffline] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [offset, setOffset] = useState(0);
 
   const fetchBookmarks = useCallback(async (reset: boolean = false) => {
+    const userId = user?.id;
+    if (!userId) {
+      setBookmarks([]);
+      setIsLoading(false);
+      setIsLoadingMore(false);
+      setError(null);
+      setIsOffline(false);
+      setHasMore(false);
+      return;
+    }
+
     const currentOffset = reset ? 0 : offset;
     
     if (reset) {
@@ -45,16 +65,33 @@ export function useBookmarks(): UseBookmarksResult {
         setOffset((prev) => prev + PAGE_SIZE);
       }
 
+      setIsOffline(false);
+      cacheLibraryPageInBackground(userId, newBookmarks, { reset });
+
       // If we received fewer than PAGE_SIZE items, there are no more
       setHasMore(newBookmarks.length === PAGE_SIZE);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch bookmarks';
+
+      if (reset && !isAuthError(err)) {
+        const cachedBookmarks = await getCachedLibrary(userId);
+        if (cachedBookmarks.length > 0) {
+          setBookmarks(cachedBookmarks);
+          setOffset(cachedBookmarks.length);
+          setHasMore(false);
+          setIsOffline(true);
+          setError(null);
+          return;
+        }
+      }
+
       setError(errorMessage);
+      setIsOffline(false);
     } finally {
       setIsLoading(false);
       setIsLoadingMore(false);
     }
-  }, [offset]);
+  }, [offset, user?.id]);
 
   const refresh = useCallback(async () => {
     setOffset(0);
@@ -70,14 +107,26 @@ export function useBookmarks(): UseBookmarksResult {
 
   // Initial load
   useEffect(() => {
-    fetchBookmarks(true);
-  }, []);
+    if (user?.id) {
+      fetchBookmarks(true);
+    } else {
+      setBookmarks([]);
+      setIsLoading(false);
+      setIsLoadingMore(false);
+      setError(null);
+      setIsOffline(false);
+      setHasMore(false);
+    }
+    // Fetch only when the signed-in user changes; offset changes are handled by explicit actions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   return {
     bookmarks,
     isLoading,
     isLoadingMore,
     error,
+    isOffline,
     hasMore,
     refresh,
     loadMore,

--- a/apps/mobile/hooks/useSearch.ts
+++ b/apps/mobile/hooks/useSearch.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { BookmarksAPI, Bookmark } from '@/lib/api';
 import { useDebounce } from './useDebounce';
+import { useAuth } from '@/contexts/AuthContext';
+import { cacheBookmarksInBackground } from '@/lib/bookmark-cache';
 
 interface UseSearchResult {
   query: string;
@@ -11,6 +13,7 @@ interface UseSearchResult {
 }
 
 export function useSearch(): UseSearchResult {
+  const { user } = useAuth();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Bookmark[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -35,6 +38,7 @@ export function useSearch(): UseSearchResult {
       .then((bookmarks) => {
         if (requestId === requestIdRef.current) {
           setResults(bookmarks);
+          cacheBookmarksInBackground(user?.id, bookmarks);
         }
       })
       .catch((err) => {
@@ -48,7 +52,7 @@ export function useSearch(): UseSearchResult {
           setIsLoading(false);
         }
       });
-  }, [debouncedQuery]);
+  }, [debouncedQuery, user?.id]);
 
   return { query, setQuery, results, isLoading, error };
 }

--- a/apps/mobile/lib/__tests__/bookmark-cache.test.ts
+++ b/apps/mobile/lib/__tests__/bookmark-cache.test.ts
@@ -1,0 +1,105 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  cacheBookmarks,
+  cacheLibraryPage,
+  clearBookmarkCache,
+  getCachedBookmark,
+  getCachedLibrary,
+  removeCachedBookmark,
+} from '../bookmark-cache';
+import { Bookmark } from '../api';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+const userId = 'user-1';
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: 'bookmark-1',
+    sourceUrl: 'https://example.com/article',
+    title: 'Cached Article',
+    userId,
+    createdAt: '2026-06-01T12:00:00.000Z',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    isPrivateLink: false,
+    isPublic: false,
+    processingStatus: 'completed',
+    ...overrides,
+  };
+}
+
+describe('bookmark cache', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('persists a refreshed library page and returns bookmarks in library order', async () => {
+    const first = makeBookmark({ id: 'bookmark-1', title: 'First' });
+    const second = makeBookmark({ id: 'bookmark-2', title: 'Second' });
+
+    await cacheLibraryPage(userId, [first, second], { reset: true });
+
+    await expect(getCachedLibrary(userId)).resolves.toEqual([first, second]);
+    await expect(getCachedBookmark(userId, 'bookmark-1')).resolves.toEqual(first);
+  });
+
+  it('appends loaded pages without duplicating existing bookmarks', async () => {
+    const first = makeBookmark({ id: 'bookmark-1', title: 'First' });
+    const second = makeBookmark({ id: 'bookmark-2', title: 'Second' });
+    const updatedFirst = makeBookmark({
+      id: 'bookmark-1',
+      title: 'First updated',
+      updatedAt: '2026-06-03T12:00:00.000Z',
+    });
+
+    await cacheLibraryPage(userId, [first], { reset: true });
+    await cacheLibraryPage(userId, [second, updatedFirst], { reset: false });
+
+    await expect(getCachedLibrary(userId)).resolves.toEqual([updatedFirst, second]);
+  });
+
+  it('does not overwrite a newer cached bookmark with stale data', async () => {
+    const newer = makeBookmark({
+      title: 'Newer cached title',
+      updatedAt: '2026-06-03T12:00:00.000Z',
+    });
+    const older = makeBookmark({
+      title: 'Older network title',
+      updatedAt: '2026-06-02T12:00:00.000Z',
+    });
+
+    await cacheBookmarks(userId, [newer]);
+    await cacheBookmarks(userId, [older]);
+
+    await expect(getCachedBookmark(userId, newer.id)).resolves.toEqual(newer);
+  });
+
+  it('removes individual bookmarks from records and the library index', async () => {
+    const first = makeBookmark({ id: 'bookmark-1', title: 'First' });
+    const second = makeBookmark({ id: 'bookmark-2', title: 'Second' });
+
+    await cacheLibraryPage(userId, [first, second], { reset: true });
+    await removeCachedBookmark(userId, 'bookmark-1');
+
+    await expect(getCachedBookmark(userId, 'bookmark-1')).resolves.toBeNull();
+    await expect(getCachedLibrary(userId)).resolves.toEqual([second]);
+  });
+
+  it('clears only the signed-in user namespace', async () => {
+    const otherUserId = 'user-2';
+    const first = makeBookmark({ id: 'bookmark-1', userId });
+    const other = makeBookmark({ id: 'bookmark-2', userId: otherUserId });
+
+    await cacheLibraryPage(userId, [first], { reset: true });
+    await cacheLibraryPage(otherUserId, [other], { reset: true });
+
+    await clearBookmarkCache(userId);
+
+    await expect(getCachedLibrary(userId)).resolves.toEqual([]);
+    await expect(getCachedLibrary(otherUserId)).resolves.toEqual([other]);
+  });
+});

--- a/apps/mobile/lib/api-errors.ts
+++ b/apps/mobile/lib/api-errors.ts
@@ -1,0 +1,20 @@
+export class APIError extends Error {
+  constructor(message: string, public readonly status?: number) {
+    super(message);
+    this.name = 'APIError';
+  }
+}
+
+export function getErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+export function isAuthError(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  return status === 401 || status === 403;
+}

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase';
+import { APIError } from './api-errors';
 
 // API configuration
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || '';
@@ -117,6 +118,12 @@ async function getAuthHeaders(): Promise<HeadersInit> {
   };
 }
 
+async function createApiError(response: Response): Promise<APIError> {
+  const errorData = await response.json().catch(() => ({}));
+  const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
+  return new APIError(errorMessage, response.status);
+}
+
 export namespace BookmarksAPI {
   export async function list(params: GetBookmarksParams = {}): Promise<Bookmark[]> {
     const { limit = 20, offset = 0, collection_id } = params;
@@ -141,7 +148,7 @@ export namespace BookmarksAPI {
       );
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        throw await createApiError(response);
       }
 
       const data: GetBookmarksResponse = await response.json();
@@ -165,7 +172,7 @@ export namespace BookmarksAPI {
         if (response.status === 404) {
           return null;
         }
-        throw new Error(`HTTP error! status: ${response.status}`);
+        throw await createApiError(response);
       }
 
       return await response.json();
@@ -185,9 +192,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
+        throw await createApiError(response);
       }
 
       return await response.json();
@@ -212,7 +217,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        throw await createApiError(response);
       }
 
       const data: GetBookmarksResponse = await response.json();
@@ -233,9 +238,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
+        throw await createApiError(response);
       }
 
       return await response.json();
@@ -254,9 +257,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
+        throw await createApiError(response);
       }
 
       return await response.json();
@@ -275,9 +276,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
+        throw await createApiError(response);
       }
 
       return await response.json();
@@ -296,9 +295,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
+        throw await createApiError(response);
       }
 
       return await response.json();
@@ -317,9 +314,7 @@ export namespace BookmarksAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
-        throw new Error(errorMessage);
+        throw await createApiError(response);
       }
 
       return await response.json();

--- a/apps/mobile/lib/bookmark-cache.ts
+++ b/apps/mobile/lib/bookmark-cache.ts
@@ -1,0 +1,218 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { InteractionManager } from 'react-native';
+
+import { Bookmark } from './api';
+
+const CACHE_VERSION = 1;
+const CACHE_PREFIX = `bookmark-cache:v${CACHE_VERSION}`;
+
+interface CachedBookmarkRecord {
+  version: typeof CACHE_VERSION;
+  userId: string;
+  bookmark: Bookmark;
+  sourceUpdatedAt: string;
+  cachedAt: string;
+}
+
+interface CachedLibraryIndex {
+  version: typeof CACHE_VERSION;
+  userId: string;
+  bookmarkIds: string[];
+  cachedAt: string;
+}
+
+interface LibraryPageInfo {
+  reset?: boolean;
+}
+
+function namespacePrefix(userId: string): string {
+  return `${CACHE_PREFIX}:${userId}:`;
+}
+
+function indexKey(userId: string): string {
+  return `${namespacePrefix(userId)}index`;
+}
+
+function bookmarkKey(userId: string, bookmarkId: string): string {
+  return `${namespacePrefix(userId)}bookmark:${bookmarkId}`;
+}
+
+function parseJson<T>(value: string | null): T | null {
+  if (!value) return null;
+
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function getBookmarkTimestamp(bookmark: Bookmark): number {
+  const timestamp = Date.parse(bookmark.updatedAt || bookmark.createdAt || '');
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function getRecordTimestamp(record: CachedBookmarkRecord): number {
+  const timestamp = Date.parse(record.sourceUpdatedAt);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function uniqueIds(ids: string[]): string[] {
+  return Array.from(new Set(ids));
+}
+
+async function readIndex(userId: string): Promise<CachedLibraryIndex> {
+  const parsed = parseJson<CachedLibraryIndex>(await AsyncStorage.getItem(indexKey(userId)));
+
+  if (!parsed || parsed.version !== CACHE_VERSION || parsed.userId !== userId) {
+    return {
+      version: CACHE_VERSION,
+      userId,
+      bookmarkIds: [],
+      cachedAt: new Date(0).toISOString(),
+    };
+  }
+
+  return {
+    ...parsed,
+    bookmarkIds: uniqueIds(parsed.bookmarkIds || []),
+  };
+}
+
+async function writeIndex(userId: string, bookmarkIds: string[]): Promise<void> {
+  const index: CachedLibraryIndex = {
+    version: CACHE_VERSION,
+    userId,
+    bookmarkIds: uniqueIds(bookmarkIds),
+    cachedAt: new Date().toISOString(),
+  };
+
+  await AsyncStorage.setItem(indexKey(userId), JSON.stringify(index));
+}
+
+async function readRecord(
+  userId: string,
+  bookmarkId: string
+): Promise<CachedBookmarkRecord | null> {
+  const parsed = parseJson<CachedBookmarkRecord>(
+    await AsyncStorage.getItem(bookmarkKey(userId, bookmarkId))
+  );
+
+  if (!parsed || parsed.version !== CACHE_VERSION || parsed.userId !== userId) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function scheduleCacheWork(work: () => Promise<void>): void {
+  InteractionManager.runAfterInteractions(() => {
+    work().catch((error) => {
+      console.warn('Failed to update bookmark cache:', error);
+    });
+  });
+}
+
+export async function getCachedBookmark(
+  userId: string,
+  bookmarkId: string
+): Promise<Bookmark | null> {
+  const record = await readRecord(userId, bookmarkId);
+  return record?.bookmark ?? null;
+}
+
+export async function getCachedLibrary(userId: string): Promise<Bookmark[]> {
+  const index = await readIndex(userId);
+  const bookmarks = await Promise.all(
+    index.bookmarkIds.map((bookmarkId) => getCachedBookmark(userId, bookmarkId))
+  );
+
+  return bookmarks.filter((bookmark): bookmark is Bookmark => bookmark !== null);
+}
+
+export async function cacheBookmarks(
+  userId: string,
+  bookmarks: Bookmark[]
+): Promise<void> {
+  await Promise.all(
+    bookmarks.map(async (bookmark) => {
+      const existingRecord = await readRecord(userId, bookmark.id);
+      const incomingTimestamp = getBookmarkTimestamp(bookmark);
+
+      if (
+        existingRecord &&
+        getRecordTimestamp(existingRecord) >= incomingTimestamp
+      ) {
+        return;
+      }
+
+      const record: CachedBookmarkRecord = {
+        version: CACHE_VERSION,
+        userId,
+        bookmark,
+        sourceUpdatedAt: bookmark.updatedAt || bookmark.createdAt,
+        cachedAt: new Date().toISOString(),
+      };
+
+      await AsyncStorage.setItem(
+        bookmarkKey(userId, bookmark.id),
+        JSON.stringify(record)
+      );
+    })
+  );
+}
+
+export function cacheBookmarksInBackground(
+  userId: string | undefined,
+  bookmarks: Bookmark[]
+): void {
+  if (!userId || bookmarks.length === 0) return;
+  scheduleCacheWork(() => cacheBookmarks(userId, bookmarks));
+}
+
+export async function cacheLibraryPage(
+  userId: string,
+  bookmarks: Bookmark[],
+  pageInfo: LibraryPageInfo = {}
+): Promise<void> {
+  await cacheBookmarks(userId, bookmarks);
+
+  const existingIndex = await readIndex(userId);
+  const bookmarkIds = bookmarks.map((bookmark) => bookmark.id);
+  const nextIds = pageInfo.reset
+    ? bookmarkIds
+    : uniqueIds([...existingIndex.bookmarkIds, ...bookmarkIds]);
+
+  await writeIndex(userId, nextIds);
+}
+
+export function cacheLibraryPageInBackground(
+  userId: string | undefined,
+  bookmarks: Bookmark[],
+  pageInfo: LibraryPageInfo = {}
+): void {
+  if (!userId) return;
+  scheduleCacheWork(() => cacheLibraryPage(userId, bookmarks, pageInfo));
+}
+
+export async function removeCachedBookmark(
+  userId: string,
+  bookmarkId: string
+): Promise<void> {
+  const index = await readIndex(userId);
+  const nextIds = index.bookmarkIds.filter((id) => id !== bookmarkId);
+
+  await Promise.all([
+    AsyncStorage.removeItem(bookmarkKey(userId, bookmarkId)),
+    writeIndex(userId, nextIds),
+  ]);
+}
+
+export async function clearBookmarkCache(userId: string): Promise<void> {
+  const keys = await AsyncStorage.getAllKeys();
+  const userKeys = keys.filter((key) => key.startsWith(namespacePrefix(userId)));
+
+  if (userKeys.length > 0) {
+    await AsyncStorage.multiRemove(userKeys);
+  }
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/apispec/bookmarks.tsp
+++ b/packages/apispec/bookmarks.tsp
@@ -33,6 +33,8 @@ enum ProcessingStatus {
 model Bookmark {
     id: string;
     sourceUrl: string;
+    createdAt: utcDateTime;
+    updatedAt: utcDateTime;
     collectionId?: string;
     collectionPath?: CollectionPathItem[];
     title?: string;


### PR DESCRIPTION
## Summary
- Add per-user bookmark caching for mobile bookmark detail, search, AI search, and library flows
- Fall back to cached library/bookmark data when online fetches fail outside auth errors
- Clear cached bookmark data on sign-out and add API error normalization plus updated TypeSpec fields

## Testing
- Unit tests added and updated for bookmark caching, auth sign-out cache clearing, and bookmark/search hooks
- Mobile UI test coverage updated for bookmark detail offline fallback and cache refresh behavior