### PR TITLE
Add bookmark read-state tracking across web and mobile

### DIFF
--- a/apps/api/src/routes/bookmarks.ts
+++ b/apps/api/src/routes/bookmarks.ts
@@ -208,19 +208,25 @@ export default async function bookmarkRoutes(fastify: FastifyInstance) {
         collection_id,
         limit = 50,
         offset = 0,
+        read_status = "all",
       } = request.query as Omit<GetBookmarksQuery, "user_id">;
       const user_id = request.userId!;
 
       fastify.log.info(
-        { collection_id, limit, offset, user_id },
+        { collection_id, limit, offset, read_status, user_id },
         "Get bookmarks request"
       );
+
+      if (!["all", "unread", "read"].includes(read_status)) {
+        return reply.status(400).send({ error: "Invalid read_status" });
+      }
 
       const bookmarks = await services.bookmark.findByUser(user_id, {
         collectionId: collection_id,
         limit,
         offset,
         includeArchived: false,
+        readStatus: read_status,
       });
 
       return reply.send({ bookmarks });
@@ -229,6 +235,31 @@ export default async function bookmarkRoutes(fastify: FastifyInstance) {
         error instanceof Error ? error.message : String(error);
       const errorStack = error instanceof Error ? error.stack : undefined;
       fastify.log.error({ errorMessage, errorStack }, "Get bookmarks error");
+      return reply.status(500).send({ error: "Internal server error" });
+    }
+  });
+
+  fastify.get<{
+    Querystring: { limit?: number; offset?: number };
+    Reply: GetBookmarksResponse | { error: string };
+  }>("/bookmarks/feed", { preHandler: authMiddleware }, async (request, reply) => {
+    try {
+      const { limit = 50, offset = 0 } = request.query;
+      const user_id = request.userId!;
+
+      fastify.log.info({ limit, offset, user_id }, "Get bookmark feed request");
+
+      const bookmarks = await services.bookmark.findFeed(user_id, {
+        limit,
+        offset,
+      });
+
+      return reply.send({ bookmarks });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorStack = error instanceof Error ? error.stack : undefined;
+      fastify.log.error({ errorMessage, errorStack }, "Get bookmark feed error");
       return reply.status(500).send({ error: "Internal server error" });
     }
   });
@@ -376,6 +407,54 @@ export default async function bookmarkRoutes(fastify: FastifyInstance) {
           return reply.status(404).send({ error: "Bookmark not found" });
         }
         fastify.log.error({ error }, "Delete bookmark error");
+        return reply.status(500).send({ error: "Internal server error" });
+      }
+    }
+  );
+
+  fastify.put<{
+    Params: { id: string };
+    Reply: Bookmark | { error: string };
+  }>(
+    "/bookmarks/:id/read",
+    { preHandler: authMiddleware },
+    async (request, reply) => {
+      try {
+        const { id } = request.params;
+        const user_id = request.userId!;
+
+        const bookmark = await services.bookmark.markRead(id, user_id);
+
+        return reply.send(bookmark);
+      } catch (error) {
+        if (error instanceof Error && error.message === "Bookmark not found") {
+          return reply.status(404).send({ error: "Bookmark not found" });
+        }
+        fastify.log.error({ error }, "Mark bookmark read error");
+        return reply.status(500).send({ error: "Internal server error" });
+      }
+    }
+  );
+
+  fastify.delete<{
+    Params: { id: string };
+    Reply: Bookmark | { error: string };
+  }>(
+    "/bookmarks/:id/read",
+    { preHandler: authMiddleware },
+    async (request, reply) => {
+      try {
+        const { id } = request.params;
+        const user_id = request.userId!;
+
+        const bookmark = await services.bookmark.markUnread(id, user_id);
+
+        return reply.send(bookmark);
+      } catch (error) {
+        if (error instanceof Error && error.message === "Bookmark not found") {
+          return reply.status(404).send({ error: "Bookmark not found" });
+        }
+        fastify.log.error({ error }, "Mark bookmark unread error");
         return reply.status(500).send({ error: "Internal server error" });
       }
     }

--- a/apps/api/src/tests/bookmark-read-routes.test.ts
+++ b/apps/api/src/tests/bookmark-read-routes.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+describe("Bookmark read route handler logic", () => {
+  const TEST_USER_ID = "user-123";
+
+  let mockFindByUser: ReturnType<typeof mock>;
+  let mockFindFeed: ReturnType<typeof mock>;
+  let mockMarkRead: ReturnType<typeof mock>;
+  let mockMarkUnread: ReturnType<typeof mock>;
+  let mockReply: any;
+  let mockFastifyLog: any;
+
+  function createMockReply() {
+    const reply: any = {};
+    reply.status = mock(() => reply);
+    reply.send = mock(() => reply);
+    return reply;
+  }
+
+  beforeEach(() => {
+    mockFindByUser = mock();
+    mockFindFeed = mock();
+    mockMarkRead = mock();
+    mockMarkUnread = mock();
+    mockReply = createMockReply();
+    mockFastifyLog = { error: mock(), info: mock() };
+  });
+
+  async function invokeListHandler(query: any = {}) {
+    try {
+      const {
+        collection_id,
+        limit = 50,
+        offset = 0,
+        read_status = "all",
+      } = query;
+
+      if (!["all", "unread", "read"].includes(read_status)) {
+        return mockReply.status(400).send({ error: "Invalid read_status" });
+      }
+
+      const bookmarks = await mockFindByUser(TEST_USER_ID, {
+        collectionId: collection_id,
+        limit,
+        offset,
+        includeArchived: false,
+        readStatus: read_status,
+      });
+
+      return mockReply.send({ bookmarks });
+    } catch (error) {
+      mockFastifyLog.error({ error }, "Get bookmarks error");
+      return mockReply.status(500).send({ error: "Internal server error" });
+    }
+  }
+
+  async function invokeFeedHandler(query: any = {}) {
+    try {
+      const { limit = 50, offset = 0 } = query;
+      const bookmarks = await mockFindFeed(TEST_USER_ID, { limit, offset });
+      return mockReply.send({ bookmarks });
+    } catch (error) {
+      mockFastifyLog.error({ error }, "Get bookmark feed error");
+      return mockReply.status(500).send({ error: "Internal server error" });
+    }
+  }
+
+  async function invokeMarkReadHandler(id = "bookmark-123") {
+    try {
+      const bookmark = await mockMarkRead(id, TEST_USER_ID);
+      return mockReply.send(bookmark);
+    } catch (error) {
+      if (error instanceof Error && error.message === "Bookmark not found") {
+        return mockReply.status(404).send({ error: "Bookmark not found" });
+      }
+      mockFastifyLog.error({ error }, "Mark bookmark read error");
+      return mockReply.status(500).send({ error: "Internal server error" });
+    }
+  }
+
+  async function invokeMarkUnreadHandler(id = "bookmark-123") {
+    try {
+      const bookmark = await mockMarkUnread(id, TEST_USER_ID);
+      return mockReply.send(bookmark);
+    } catch (error) {
+      if (error instanceof Error && error.message === "Bookmark not found") {
+        return mockReply.status(404).send({ error: "Bookmark not found" });
+      }
+      mockFastifyLog.error({ error }, "Mark bookmark unread error");
+      return mockReply.status(500).send({ error: "Internal server error" });
+    }
+  }
+
+  it("should request the unread feed", async () => {
+    const bookmark = { id: "bookmark-1", isRead: false };
+    mockFindFeed.mockResolvedValue([bookmark]);
+
+    await invokeFeedHandler({ limit: 10, offset: 20 });
+
+    expect(mockFindFeed).toHaveBeenCalledWith(TEST_USER_ID, {
+      limit: 10,
+      offset: 20,
+    });
+    expect(mockReply.send).toHaveBeenCalledWith({ bookmarks: [bookmark] });
+  });
+
+  it("should pass read_status through library queries", async () => {
+    mockFindByUser.mockResolvedValue([]);
+
+    await invokeListHandler({
+      collection_id: "collection-1",
+      read_status: "read",
+    });
+
+    expect(mockFindByUser).toHaveBeenCalledWith(TEST_USER_ID, {
+      collectionId: "collection-1",
+      includeArchived: false,
+      limit: 50,
+      offset: 0,
+      readStatus: "read",
+    });
+    expect(mockReply.send).toHaveBeenCalledWith({ bookmarks: [] });
+  });
+
+  it("should reject invalid read_status values", async () => {
+    await invokeListHandler({ read_status: "finished" });
+
+    expect(mockReply.status).toHaveBeenCalledWith(400);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      error: "Invalid read_status",
+    });
+    expect(mockFindByUser).not.toHaveBeenCalled();
+  });
+
+  it("should mark a bookmark read", async () => {
+    const updated = {
+      id: "bookmark-123",
+      isRead: true,
+      readAt: "2026-06-17T00:00:00.000Z",
+    };
+    mockMarkRead.mockResolvedValue(updated);
+
+    await invokeMarkReadHandler();
+
+    expect(mockMarkRead).toHaveBeenCalledWith("bookmark-123", TEST_USER_ID);
+    expect(mockReply.send).toHaveBeenCalledWith(updated);
+  });
+
+  it("should mark a bookmark unread", async () => {
+    const updated = { id: "bookmark-123", isRead: false };
+    mockMarkUnread.mockResolvedValue(updated);
+
+    await invokeMarkUnreadHandler();
+
+    expect(mockMarkUnread).toHaveBeenCalledWith("bookmark-123", TEST_USER_ID);
+    expect(mockReply.send).toHaveBeenCalledWith(updated);
+  });
+
+  it("should return 404 when marking another user's bookmark read", async () => {
+    mockMarkRead.mockRejectedValue(new Error("Bookmark not found"));
+
+    await invokeMarkReadHandler();
+
+    expect(mockReply.status).toHaveBeenCalledWith(404);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      error: "Bookmark not found",
+    });
+  });
+});

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -17,6 +17,15 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
+          title: 'Home',
+          tabBarIcon: ({ color, focused }) => (
+            <TabBarIcon name={focused ? 'home' : 'home-outline'} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="library"
+        options={{
           title: 'Library',
           tabBarIcon: ({ color, focused }) => (
             <TabBarIcon name={focused ? 'library' : 'library-outline'} color={color} />

--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -1,23 +1,16 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
-  StyleSheet,
-  View,
-  Text,
-  Pressable,
   ActivityIndicator,
+  FlatList,
+  Pressable,
   RefreshControl,
+  StyleSheet,
+  Text,
+  View,
 } from 'react-native';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { BlurView } from 'expo-blur';
-import Animated, {
-  useAnimatedScrollHandler,
-  useSharedValue,
-  useAnimatedStyle,
-  interpolate,
-  Extrapolation,
-} from 'react-native-reanimated';
 
 import { BookmarkCard } from '@/components/BookmarkCard';
 import { useBookmarks } from '@/hooks/useBookmarks';
@@ -25,14 +18,19 @@ import { Bookmark } from '@/lib/api';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
-const HEADER_HEIGHT = 56;
-const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
+type ReadStatus = 'all' | 'unread' | 'read';
 
-export default function HomeScreen() {
+const filters: { label: string; value: ReadStatus }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Unread', value: 'unread' },
+  { label: 'Read', value: 'read' },
+];
+
+export default function LibraryScreen() {
   const router = useRouter();
   const colorScheme = useColorScheme() ?? 'light';
   const colors = Colors[colorScheme];
-  const insets = useSafeAreaInsets();
+  const [readStatus, setReadStatus] = useState<ReadStatus>('all');
   const {
     bookmarks,
     isLoading,
@@ -42,48 +40,10 @@ export default function HomeScreen() {
     refresh,
     loadMore,
     toggleRead,
-  } = useBookmarks({ mode: 'feed' });
-
-  const scrollY = useSharedValue(0);
-
-  const scrollHandler = useAnimatedScrollHandler({
-    onScroll: (event) => {
-      scrollY.value = event.contentOffset.y;
-    },
-  });
-
-  const headerBlurStyle = useAnimatedStyle(() => {
-    const intensity = interpolate(
-      scrollY.value,
-      [0, 50],
-      [0, 1],
-      Extrapolation.CLAMP,
-    );
-    return {
-      opacity: intensity,
-    };
-  });
-
-  const headerBorderStyle = useAnimatedStyle(() => {
-    const opacity = interpolate(
-      scrollY.value,
-      [0, 50],
-      [0, 1],
-      Extrapolation.CLAMP,
-    );
-    return {
-      borderBottomColor: colors.border,
-      borderBottomWidth: 1,
-      opacity,
-    };
-  });
+  } = useBookmarks({ mode: 'library', readStatus });
 
   const handleBookmarkPress = useCallback((bookmark: Bookmark) => {
     router.push(`/bookmark/${bookmark.id}`);
-  }, [router]);
-
-  const handleSearchPress = useCallback(() => {
-    router.push('/search');
   }, [router]);
 
   const renderBookmark = useCallback(
@@ -92,10 +52,17 @@ export default function HomeScreen() {
         bookmark={item}
         onPress={handleBookmarkPress}
         onToggleRead={toggleRead}
+        showReadStatus
       />
     ),
     [handleBookmarkPress, toggleRead]
   );
+
+  const handleEndReached = useCallback(() => {
+    if (hasMore && !isLoadingMore) {
+      loadMore();
+    }
+  }, [hasMore, isLoadingMore, loadMore]);
 
   const renderFooter = useCallback(() => {
     if (!isLoadingMore) return null;
@@ -111,51 +78,22 @@ export default function HomeScreen() {
     return (
       <View style={styles.emptyContainer}>
         <View style={[styles.emptyIconContainer, { backgroundColor: colors.backgroundSecondary }]}>
-          <Ionicons name="bookmark-outline" size={32} color={colors.textSecondary} />
+          <Ionicons name="library-outline" size={32} color={colors.textSecondary} />
         </View>
         <Text style={[styles.emptyTitle, { color: colors.text }]}>
-          No bookmarks yet
+          No bookmarks found
         </Text>
         <Text style={[styles.emptySubtitle, { color: colors.textSecondary }]}>
-          Unread bookmarks appear here. Read bookmarks stay in your library.
+          Your complete saved library will appear here.
         </Text>
       </View>
     );
   }, [isLoading, colors]);
 
-  const handleEndReached = useCallback(() => {
-    if (hasMore && !isLoadingMore) {
-      loadMore();
-    }
-  }, [hasMore, isLoadingMore, loadMore]);
-
-  const keyExtractor = useCallback((item: Bookmark) => item.id, []);
-
-  const headerContent = (
-    <View style={styles.headerInner}>
-      <View style={styles.brandContainer}>
-        <Text style={styles.brandEmoji}>🐬</Text>
-        <Text style={[styles.brandTitle, { color: colors.text }]}>Home</Text>
-      </View>
-      <Pressable
-        onPress={handleSearchPress}
-        style={({ pressed }) => [
-          styles.searchButton,
-          { backgroundColor: colors.backgroundSecondary, opacity: pressed ? 0.7 : 1 },
-        ]}
-        hitSlop={8}
-      >
-        <Ionicons name="search-outline" size={20} color={colors.text} />
-      </Pressable>
-    </View>
-  );
-
   if (isLoading) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top']}>
-        <View style={styles.header}>
-          {headerContent}
-        </View>
+        <Header colors={colors} readStatus={readStatus} onFilterChange={setReadStatus} />
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.tint} />
         </View>
@@ -166,9 +104,7 @@ export default function HomeScreen() {
   if (error) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top']}>
-        <View style={styles.header}>
-          {headerContent}
-        </View>
+        <Header colors={colors} readStatus={readStatus} onFilterChange={setReadStatus} />
         <View style={styles.errorContainer}>
           <Ionicons name="alert-circle-outline" size={48} color={colors.textSecondary} />
           <Text style={[styles.errorTitle, { color: colors.text }]}>
@@ -184,37 +120,21 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top']}>
-      <View style={[styles.headerWrapper, { top: insets.top }]}>
-        <AnimatedBlurView
-          intensity={80}
-          tint={colorScheme === 'dark' ? 'dark' : 'light'}
-          style={[StyleSheet.absoluteFill, headerBlurStyle]}
-        />
-        <View style={[StyleSheet.absoluteFill, { backgroundColor: colors.background, opacity: 0.7 }]} />
-        {headerContent}
-        <Animated.View style={[styles.headerBorder, headerBorderStyle]} />
-      </View>
-
-      <Animated.FlatList
+      <Header colors={colors} readStatus={readStatus} onFilterChange={setReadStatus} />
+      <FlatList
         data={bookmarks}
         renderItem={renderBookmark}
-        keyExtractor={keyExtractor}
-        contentContainerStyle={[
-          { paddingTop: HEADER_HEIGHT },
-          bookmarks.length === 0 ? styles.emptyList : undefined,
-        ]}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={bookmarks.length === 0 ? styles.emptyList : undefined}
         ListEmptyComponent={renderEmpty}
         ListFooterComponent={renderFooter}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
-        onScroll={scrollHandler}
-        scrollEventThrottle={16}
         refreshControl={
           <RefreshControl
             refreshing={false}
             onRefresh={refresh}
             tintColor={colors.tint}
-            progressViewOffset={HEADER_HEIGHT}
           />
         }
         showsVerticalScrollIndicator={false}
@@ -223,59 +143,83 @@ export default function HomeScreen() {
   );
 }
 
+function Header({
+  colors,
+  readStatus,
+  onFilterChange,
+}: {
+  colors: typeof Colors.light;
+  readStatus: ReadStatus;
+  onFilterChange: (status: ReadStatus) => void;
+}) {
+  return (
+    <View style={[styles.header, { borderBottomColor: colors.border }]}>
+      <View>
+        <Text style={[styles.title, { color: colors.text }]}>Library</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          All saved bookmarks
+        </Text>
+      </View>
+      <View style={[styles.segmented, { backgroundColor: colors.backgroundSecondary }]}>
+        {filters.map((filter) => {
+          const isActive = readStatus === filter.value;
+          return (
+            <Pressable
+              key={filter.value}
+              onPress={() => onFilterChange(filter.value)}
+              style={[
+                styles.segment,
+                isActive && { backgroundColor: colors.tint },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.segmentText,
+                  { color: isActive ? '#fff' : colors.textSecondary },
+                ]}
+              >
+                {filter.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  headerWrapper: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: HEADER_HEIGHT,
-    zIndex: 10,
-    overflow: 'hidden',
-  },
   header: {
-    height: HEADER_HEIGHT,
-  },
-  headerInner: {
-    height: HEADER_HEIGHT,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
     paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    gap: 12,
   },
-  headerBorder: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    height: 1,
-  },
-  brandContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  brandEmoji: {
+  title: {
     fontSize: 24,
-  },
-  brandTitle: {
-    fontSize: 20,
     fontWeight: '700',
   },
-  searchButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    justifyContent: 'center',
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5,
+  subtitle: {
+    fontSize: 14,
+    marginTop: 2,
+  },
+  segmented: {
+    flexDirection: 'row',
+    borderRadius: 8,
+    padding: 3,
+    alignSelf: 'flex-start',
+  },
+  segment: {
+    borderRadius: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  segmentText: {
+    fontSize: 13,
+    fontWeight: '600',
   },
   loadingContainer: {
     flex: 1,
@@ -323,7 +267,6 @@ const styles = StyleSheet.create({
   emptySubtitle: {
     fontSize: 14,
     textAlign: 'center',
-    maxWidth: 280,
   },
   footerLoader: {
     paddingVertical: 20,

--- a/apps/mobile/app/bookmark/[id].tsx
+++ b/apps/mobile/app/bookmark/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   StyleSheet,
   View,
@@ -62,6 +62,11 @@ export default function BookmarkDetailScreen() {
   const [isShareModalVisible, setIsShareModalVisible] = useState(false);
   const [isShareLoading, setIsShareLoading] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
+  const [isRead, setIsRead] = useState(false);
+  const [readAt, setReadAt] = useState<string | undefined>(undefined);
+  const [isReadLoading, setIsReadLoading] = useState(false);
+  const [suppressAutoRead, setSuppressAutoRead] = useState(false);
+  const autoReadTriggeredRef = useRef(false);
 
   // Markdown styles based on color scheme - must be called before any early returns
   const markdownStyles = useMemo(() => ({
@@ -184,6 +189,10 @@ export default function BookmarkDetailScreen() {
         setIsLiked(data.isLikedByCurrentUser ?? false);
         setLikeCount(data.likeCount ?? 0);
         setIsShared(data.isPublic ?? false);
+        setIsRead(data.isRead ?? Boolean(data.readAt));
+        setReadAt(data.readAt);
+        setSuppressAutoRead(false);
+        autoReadTriggeredRef.current = false;
       } else {
         setError('Bookmark not found');
       }
@@ -236,6 +245,83 @@ export default function BookmarkDetailScreen() {
     }
   };
 
+  const applyReadState = useCallback((updated: Bookmark) => {
+    setBookmark(updated);
+    setIsRead(updated.isRead ?? Boolean(updated.readAt));
+    setReadAt(updated.readAt);
+  }, []);
+
+  const markReadAutomatically = useCallback(async () => {
+    if (!bookmark || isRead || suppressAutoRead || autoReadTriggeredRef.current) {
+      return;
+    }
+
+    autoReadTriggeredRef.current = true;
+    try {
+      const updated = await BookmarksAPI.markRead(bookmark.id);
+      applyReadState(updated);
+    } catch (error) {
+      autoReadTriggeredRef.current = false;
+      console.error('Failed to automatically mark bookmark read:', error);
+    }
+  }, [applyReadState, bookmark, isRead, suppressAutoRead]);
+
+  useEffect(() => {
+    if (!bookmark || isRead || suppressAutoRead) return;
+
+    const timeoutId = setTimeout(() => {
+      markReadAutomatically();
+    }, 20000);
+
+    return () => clearTimeout(timeoutId);
+  }, [bookmark, isRead, markReadAutomatically, suppressAutoRead]);
+
+  const handleScroll = useCallback((event: any) => {
+    const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+    if (!contentSize?.height || contentSize.height <= layoutMeasurement.height) {
+      return;
+    }
+
+    const scrollRatio =
+      (contentOffset.y + layoutMeasurement.height) / contentSize.height;
+
+    if (scrollRatio >= 0.7) {
+      markReadAutomatically();
+    }
+  }, [markReadAutomatically]);
+
+  const handleReadToggle = async () => {
+    if (!bookmark || isReadLoading) return;
+
+    const previousBookmark = bookmark;
+    const previousIsRead = isRead;
+    const previousReadAt = readAt;
+
+    setIsRead(!isRead);
+    setReadAt(isRead ? undefined : new Date().toISOString());
+    setIsReadLoading(true);
+
+    try {
+      const updated = isRead
+        ? await BookmarksAPI.markUnread(bookmark.id)
+        : await BookmarksAPI.markRead(bookmark.id);
+      applyReadState(updated);
+      setSuppressAutoRead(isRead);
+    } catch (error) {
+      console.error('Failed to update read state:', error);
+      setBookmark(previousBookmark);
+      setIsRead(previousIsRead);
+      setReadAt(previousReadAt);
+      Alert.alert(
+        "Error",
+        "Failed to update read status. Please try again later.",
+        [{ text: "OK" }]
+      );
+    } finally {
+      setIsReadLoading(false);
+    }
+  };
+
   const handleShareToggle = async () => {
     if (!bookmark || isShareLoading) return;
 
@@ -250,7 +336,7 @@ export default function BookmarkDetailScreen() {
       setIsShared(result.isPublic);
       setShareUrl(result.shareUrl);
       setIsShareModalVisible(true);
-    } catch (err) {
+    } catch {
       Alert.alert('Error', 'Failed to share bookmark. Please try again.');
     } finally {
       setIsShareLoading(false);
@@ -266,7 +352,7 @@ export default function BookmarkDetailScreen() {
       setIsShared(result.isPublic);
       setShareUrl('');
       setIsShareModalVisible(false);
-    } catch (err) {
+    } catch {
       Alert.alert('Error', 'Failed to unshare bookmark. Please try again.');
     } finally {
       setIsShareLoading(false);
@@ -357,6 +443,17 @@ export default function BookmarkDetailScreen() {
             )}
           </Pressable>
           <Pressable
+            onPress={handleReadToggle}
+            style={styles.headerButton}
+            disabled={isReadLoading}
+          >
+            <Ionicons
+              name={isRead ? "return-up-back-outline" : "checkmark-done-outline"}
+              size={22}
+              color={isRead ? colors.tint : colors.textSecondary}
+            />
+          </Pressable>
+          <Pressable
             onPress={handleShareToggle}
             style={styles.headerButton}
             disabled={isShareLoading}
@@ -377,6 +474,8 @@ export default function BookmarkDetailScreen() {
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
       >
         {/* Hero Image */}
         {image && (
@@ -420,6 +519,14 @@ export default function BookmarkDetailScreen() {
           <Text style={[styles.date, { color: colors.textSecondary }]}>
             Saved on {formatDate(bookmark.createdAt)}
           </Text>
+
+          {isRead && (
+            <View style={[styles.readBadge, { borderColor: colors.border }]}>
+              <Text style={[styles.readBadgeText, { color: colors.textSecondary }]}>
+                Read
+              </Text>
+            </View>
+          )}
 
           {/* Tags */}
           {bookmark.cosmicTags && bookmark.cosmicTags.length > 0 && (
@@ -651,6 +758,17 @@ const styles = StyleSheet.create({
   },
   date: {
     fontSize: 14,
+  },
+  readBadge: {
+    alignSelf: 'flex-start',
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  readBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
   },
   tagsContainer: {
     flexDirection: 'row',

--- a/apps/mobile/components/BookmarkCard.tsx
+++ b/apps/mobile/components/BookmarkCard.tsx
@@ -7,6 +7,8 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 interface BookmarkCardProps {
   bookmark: Bookmark;
   onPress?: (bookmark: Bookmark) => void;
+  onToggleRead?: (bookmark: Bookmark) => void;
+  showReadStatus?: boolean;
 }
 
 function extractDomain(url: string): string {
@@ -18,7 +20,12 @@ function extractDomain(url: string): string {
   }
 }
 
-export function BookmarkCard({ bookmark, onPress }: BookmarkCardProps) {
+export function BookmarkCard({
+  bookmark,
+  onPress,
+  onToggleRead,
+  showReadStatus = false,
+}: BookmarkCardProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const colors = Colors[colorScheme];
 
@@ -33,12 +40,18 @@ export function BookmarkCard({ bookmark, onPress }: BookmarkCardProps) {
     extractDomain(bookmark.sourceUrl || '');
   const image = bookmark.metadata?.openGraph?.image;
   const description = bookmark.cosmicBriefSummary || bookmark.metadata?.openGraph?.description || '';
+  const isRead = bookmark.isRead ?? Boolean(bookmark.readAt);
 
   // Display collection name if available, otherwise fall back to site name
   const displayName = collectionName || siteName;
 
   const handlePress = () => {
     onPress?.(bookmark);
+  };
+
+  const handleToggleRead = (event: any) => {
+    event.stopPropagation?.();
+    onToggleRead?.(bookmark);
   };
 
   return (
@@ -70,6 +83,14 @@ export function BookmarkCard({ bookmark, onPress }: BookmarkCardProps) {
             </View>
           )}
 
+          {showReadStatus && isRead && (
+            <View style={[styles.readBadge, { borderColor: colors.border }]}>
+              <Text style={[styles.readBadgeText, { color: colors.textSecondary }]}>
+                Read
+              </Text>
+            </View>
+          )}
+
           {/* Title */}
           <Text style={[styles.title, { color: colors.text }]} numberOfLines={2}>
             {bookmark.title || 'Untitled'}
@@ -97,6 +118,24 @@ export function BookmarkCard({ bookmark, onPress }: BookmarkCardProps) {
               ))}
             </View>
           )}
+
+          {onToggleRead && (
+            <Pressable
+              onPress={handleToggleRead}
+              style={({ pressed }) => [
+                styles.readButton,
+                {
+                  borderColor: colors.border,
+                  opacity: pressed ? 0.7 : 1,
+                },
+              ]}
+              hitSlop={8}
+            >
+              <Text style={[styles.readButtonText, { color: colors.textSecondary }]}>
+                {isRead ? 'Mark unread' : 'Mark read'}
+              </Text>
+            </Pressable>
+          )}
         </View>
 
         {/* Right side: Image */}
@@ -119,6 +158,17 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     paddingHorizontal: 16,
     borderBottomWidth: 1,
+  },
+  readBadge: {
+    alignSelf: 'flex-start',
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  readBadgeText: {
+    fontSize: 11,
+    fontWeight: '600',
   },
   content: {
     flexDirection: 'row',
@@ -174,6 +224,18 @@ const styles = StyleSheet.create({
   },
   tagText: {
     fontSize: 12,
+  },
+  readButton: {
+    alignSelf: 'flex-start',
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginTop: 2,
+  },
+  readButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
   },
   imageContainer: {
     width: 80,

--- a/apps/mobile/hooks/useBookmarks.ts
+++ b/apps/mobile/hooks/useBookmarks.ts
@@ -11,9 +11,18 @@ interface UseBookmarksResult {
   hasMore: boolean;
   refresh: () => Promise<void>;
   loadMore: () => Promise<void>;
+  toggleRead: (bookmark: Bookmark) => Promise<void>;
 }
 
-export function useBookmarks(): UseBookmarksResult {
+interface UseBookmarksOptions {
+  mode?: 'feed' | 'library';
+  readStatus?: 'all' | 'unread' | 'read';
+}
+
+export function useBookmarks({
+  mode = 'library',
+  readStatus = 'all',
+}: UseBookmarksOptions = {}): UseBookmarksResult {
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -32,10 +41,17 @@ export function useBookmarks(): UseBookmarksResult {
     }
 
     try {
-      const newBookmarks = await BookmarksAPI.list({
-        limit: PAGE_SIZE,
-        offset: currentOffset,
-      });
+      const newBookmarks =
+        mode === 'feed'
+          ? await BookmarksAPI.feed({
+              limit: PAGE_SIZE,
+              offset: currentOffset,
+            })
+          : await BookmarksAPI.list({
+              limit: PAGE_SIZE,
+              offset: currentOffset,
+              read_status: readStatus,
+            });
 
       if (reset) {
         setBookmarks(newBookmarks);
@@ -54,7 +70,7 @@ export function useBookmarks(): UseBookmarksResult {
       setIsLoading(false);
       setIsLoadingMore(false);
     }
-  }, [offset]);
+  }, [mode, offset, readStatus]);
 
   const refresh = useCallback(async () => {
     setOffset(0);
@@ -71,7 +87,33 @@ export function useBookmarks(): UseBookmarksResult {
   // Initial load
   useEffect(() => {
     fetchBookmarks(true);
-  }, []);
+  }, [mode, readStatus]);
+
+  const toggleRead = useCallback(async (bookmark: Bookmark) => {
+    const currentIsRead = bookmark.isRead ?? Boolean(bookmark.readAt);
+    const updated = currentIsRead
+      ? await BookmarksAPI.markUnread(bookmark.id)
+      : await BookmarksAPI.markRead(bookmark.id);
+
+    setBookmarks((prev) => {
+      if (mode === 'feed' && (updated.isRead ?? Boolean(updated.readAt))) {
+        return prev.filter((item) => item.id !== bookmark.id);
+      }
+
+      if (mode === 'library' && readStatus !== 'all') {
+        const updatedIsRead = updated.isRead ?? Boolean(updated.readAt);
+        const matchesFilter =
+          (readStatus === 'read' && updatedIsRead) ||
+          (readStatus === 'unread' && !updatedIsRead);
+
+        if (!matchesFilter) {
+          return prev.filter((item) => item.id !== bookmark.id);
+        }
+      }
+
+      return prev.map((item) => (item.id === bookmark.id ? updated : item));
+    });
+  }, [mode, readStatus]);
 
   return {
     bookmarks,
@@ -81,5 +123,6 @@ export function useBookmarks(): UseBookmarksResult {
     hasMore,
     refresh,
     loadMore,
+    toggleRead,
   };
 }

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -49,6 +49,8 @@ export interface Bookmark {
   isLikedByCurrentUser?: boolean;
   isPublic?: boolean;
   shareSlug?: string;
+  readAt?: string;
+  isRead?: boolean;
   isPrivateLink?: boolean;
   processingStatus?: 'idle' | 'processing' | 'completed' | 'failed';
   processingError?: string;
@@ -67,6 +69,7 @@ export interface GetBookmarksParams {
   limit?: number;
   offset?: number;
   collection_id?: string;
+  read_status?: 'all' | 'unread' | 'read';
 }
 
 export interface CreateBookmarkParams {
@@ -119,7 +122,7 @@ async function getAuthHeaders(): Promise<HeadersInit> {
 
 export namespace BookmarksAPI {
   export async function list(params: GetBookmarksParams = {}): Promise<Bookmark[]> {
-    const { limit = 20, offset = 0, collection_id } = params;
+    const { limit = 20, offset = 0, collection_id, read_status } = params;
     
     try {
       const headers = await getAuthHeaders();
@@ -128,6 +131,9 @@ export namespace BookmarksAPI {
       queryParams.append('offset', offset.toString());
       if (collection_id) {
         queryParams.append('collection_id', collection_id);
+      }
+      if (read_status) {
+        queryParams.append('read_status', read_status);
       }
 
       const url = `${API_URL}/bookmarks?${queryParams.toString()}`;
@@ -149,6 +155,32 @@ export namespace BookmarksAPI {
     } catch (error) {
 
       console.error('Error fetching bookmarks:', {error});
+      throw error;
+    }
+  }
+
+  export async function feed(params: Pick<GetBookmarksParams, 'limit' | 'offset'> = {}): Promise<Bookmark[]> {
+    const { limit = 20, offset = 0 } = params;
+
+    try {
+      const headers = await getAuthHeaders();
+      const queryParams = new URLSearchParams();
+      queryParams.append('limit', limit.toString());
+      queryParams.append('offset', offset.toString());
+
+      const response = await fetch(`${API_URL}/bookmarks/feed?${queryParams.toString()}`, {
+        method: 'GET',
+        headers,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data: GetBookmarksResponse = await response.json();
+      return data.bookmarks || [];
+    } catch (error) {
+      console.error('Error fetching bookmark feed:', error);
       throw error;
     }
   }
@@ -283,6 +315,48 @@ export namespace BookmarksAPI {
       return await response.json();
     } catch (error) {
       console.error('Error unliking bookmark:', error);
+      throw error;
+    }
+  }
+
+  export async function markRead(id: string): Promise<Bookmark> {
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch(`${API_URL}/bookmarks/${id}/read`, {
+        method: 'PUT',
+        headers,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('Error marking bookmark read:', error);
+      throw error;
+    }
+  }
+
+  export async function markUnread(id: string): Promise<Bookmark> {
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch(`${API_URL}/bookmarks/${id}/read`, {
+        method: 'DELETE',
+        headers,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMessage = errorData.error || `HTTP error! status: ${response.status}`;
+        throw new Error(errorMessage);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('Error marking bookmark unread:', error);
       throw error;
     }
   }

--- a/apps/web/app/(private)/my/dashboard/page.tsx
+++ b/apps/web/app/(private)/my/dashboard/page.tsx
@@ -1,12 +1,79 @@
+import { BookmarksAPI } from "@/lib/api/bookmarks";
+import { Bookmark } from "@cosmic-dolphin/api-client";
+import { Suspense } from "react";
+import { InboxIcon } from "lucide-react";
+import { BookmarkListCard } from "@/components/bookmark/bookmark-list-card";
 
+async function FeedList() {
+  const bookmarks = await BookmarksAPI.feed();
 
+  if (!bookmarks || bookmarks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4">
+          <InboxIcon className="w-8 h-8 text-gray-400" />
+        </div>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          You&apos;re caught up
+        </h3>
+        <p className="text-gray-500 dark:text-gray-400 max-w-sm">
+          Unread bookmarks appear here. Read bookmarks stay available in your
+          library.
+        </p>
+      </div>
+    );
+  }
 
+  return (
+    <div className="divide-y divide-gray-100 dark:divide-gray-800">
+      {bookmarks.map((bookmark: Bookmark) => (
+        <BookmarkListCard
+          key={bookmark.id}
+          bookmark={bookmark}
+          showReadToggle
+        />
+      ))}
+    </div>
+  );
+}
+
+const LoadingFeed = () => (
+  <div className="divide-y divide-gray-100 dark:divide-gray-800">
+    {Array.from({ length: 5 }).map((_, i) => (
+      <article
+        key={i}
+        className="py-6 border-b border-gray-100 dark:border-gray-800 last:border-b-0 animate-pulse"
+      >
+        <div className="flex gap-6">
+          <div className="flex-1 min-w-0 flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-sm">
+              <div className="w-5 h-5 rounded-sm bg-gray-200 dark:bg-gray-700" />
+              <div className="h-5 w-40 bg-gray-200 dark:bg-gray-700 rounded" />
+            </div>
+            <div className="h-7 w-full bg-gray-200 dark:bg-gray-700 rounded" />
+            <div className="h-12 w-full bg-gray-100 dark:bg-gray-800 rounded" />
+          </div>
+          <div className="w-24 h-24 sm:w-32 sm:h-32 rounded-md bg-gray-200 dark:bg-gray-700 shrink-0" />
+        </div>
+      </article>
+    ))}
+  </div>
+);
 
 export default async function Index() {
-
-    return (
-        <div>
-
-        </div>
-    )
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+          Home
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Your unread bookmark feed.
+        </p>
+      </div>
+      <Suspense fallback={<LoadingFeed />}>
+        <FeedList />
+      </Suspense>
+    </main>
+  );
 }

--- a/apps/web/app/(private)/my/library/page.tsx
+++ b/apps/web/app/(private)/my/library/page.tsx
@@ -1,117 +1,53 @@
 import { BookmarksAPI } from "@/lib/api/bookmarks";
-import { Bookmark } from "@cosmic-dolphin/api-client";
+import { Bookmark, BookmarkReadStatus } from "@cosmic-dolphin/api-client";
 import Link from "next/link";
 import { Suspense } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Bookmark as BookmarkIcon, LockIcon } from "lucide-react";
+import { Bookmark as BookmarkIcon } from "lucide-react";
+import { BookmarkListCard } from "@/components/bookmark/bookmark-list-card";
 
-function extractDomain(url: string): string {
-  try {
-    const domain = new URL(url).hostname.replace("www.", "");
-    return domain;
-  } catch {
-    return "";
+const readFilters: {
+  label: string;
+  value: BookmarkReadStatus;
+}[] = [
+  { label: "All", value: BookmarkReadStatus.All },
+  { label: "Unread", value: BookmarkReadStatus.Unread },
+  { label: "Read", value: BookmarkReadStatus.Read },
+];
+
+function normalizeReadStatus(
+  readStatus?: string
+): BookmarkReadStatus {
+  if (readStatus === BookmarkReadStatus.Unread) {
+    return BookmarkReadStatus.Unread;
   }
+  if (readStatus === BookmarkReadStatus.Read) {
+    return BookmarkReadStatus.Read;
+  }
+  return BookmarkReadStatus.All;
 }
 
-const BookmarkCard = ({ bookmark }: { bookmark: Bookmark }) => {
-  // Get the immediate (last) collection from the path
-  const immediateCollection = bookmark.collectionPath?.length
-    ? bookmark.collectionPath[bookmark.collectionPath.length - 1]
-    : null;
-  const collectionName = immediateCollection?.name;
-
-  const siteName =
-    bookmark.metadata?.openGraph?.siteName ||
-    extractDomain(bookmark.sourceUrl || "");
-  const image = bookmark.metadata?.openGraph?.image;
-  const description =
-    bookmark.cosmicBriefSummary ||
-    bookmark.metadata?.openGraph?.description ||
-    "";
-
-  // Display collection name if available, otherwise fall back to site name
-  const displayName = collectionName || siteName;
-
-  return (
-    <article className="group py-6 border-b border-gray-100 dark:border-gray-800 last:border-b-0">
-      <div className="flex gap-6">
-        {/* Content */}
-        <div className="flex-1 min-w-0 flex flex-col gap-2">
-          {/* Publication header */}
-          {displayName && (
-            <div className="flex items-center gap-2 text-sm">
-              <div className="w-5 h-5 rounded-sm bg-gradient-to-br from-gray-700 to-gray-900 dark:from-gray-300 dark:to-gray-500 flex items-center justify-center">
-                <span className="text-[10px] font-bold text-white dark:text-gray-900 uppercase">
-                  {displayName.charAt(0)}
-                </span>
-              </div>
-              <span className="text-gray-600 dark:text-gray-400">
-                In{" "}
-                <span className="font-medium text-gray-900 dark:text-gray-100">
-                  {displayName}
-                </span>
-              </span>
-            </div>
-          )}
-
-          {/* Title */}
-          <Link href={`/bookmarks/${bookmark.id}`} className="block">
-            <h2 className="flex items-start gap-1.5 text-lg sm:text-xl font-bold text-gray-900 dark:text-gray-100 leading-tight line-clamp-2 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
-              {bookmark.isPrivateLink && (
-                <LockIcon className="mt-1 size-4 shrink-0 text-gray-400 dark:text-gray-500" />
-              )}
-              {bookmark.title}
-            </h2>
-          </Link>
-
-          {/* Description */}
-          {description && (
-            <p className="text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-relaxed">
-              {description}
-            </p>
-          )}
-
-          {/* Tags */}
-          {bookmark.cosmicTags && bookmark.cosmicTags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-1">
-              {bookmark.cosmicTags.slice(0, 3).map((tag) => (
-                <Badge
-                  key={tag}
-                  variant="secondary"
-                  className="text-xs px-2 py-0 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-                >
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Thumbnail */}
-        {image && (
-          <Link href={`/bookmarks/${bookmark.id}`} className="shrink-0">
-            <div className="w-24 h-24 sm:w-32 sm:h-32 rounded-md overflow-hidden bg-gray-100 dark:bg-gray-800">
-              <img
-                src={image}
-                alt=""
-                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-              />
-            </div>
-          </Link>
-        )}
-      </div>
-    </article>
-  );
-};
+function buildLibraryFilterHref(
+  readStatus: BookmarkReadStatus,
+  collectionId?: string
+) {
+  const params = new URLSearchParams();
+  if (collectionId) params.set("collection_id", collectionId);
+  if (readStatus !== BookmarkReadStatus.All) {
+    params.set("read_status", readStatus);
+  }
+  const query = params.toString();
+  return query ? `/my/library?${query}` : "/my/library";
+}
 
 async function BookmarksList({
   searchParams,
 }: {
-  searchParams: { collection_id?: string };
+  searchParams: { collection_id?: string; read_status?: string };
 }) {
+  const readStatus = normalizeReadStatus(searchParams.read_status);
   const bookmarks = await BookmarksAPI.list({
     collection_id: searchParams.collection_id,
+    read_status: readStatus,
   });
 
   if (!bookmarks || bookmarks.length === 0) {
@@ -121,10 +57,12 @@ async function BookmarksList({
           <BookmarkIcon className="w-8 h-8 text-gray-400" />
         </div>
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
-          No bookmarks yet
+          No bookmarks found
         </h3>
         <p className="text-gray-500 dark:text-gray-400 max-w-sm">
-          Start saving articles and pages to build your personal library.
+          {readStatus === BookmarkReadStatus.Read
+            ? "Bookmarks you mark as read will stay here in your complete library."
+            : "Start saving articles and pages to build your personal library."}
         </p>
       </div>
     );
@@ -133,7 +71,11 @@ async function BookmarksList({
   return (
     <div className="divide-y divide-gray-100 dark:divide-gray-800">
       {bookmarks.map((bookmark: Bookmark) => (
-        <BookmarkCard key={bookmark.id} bookmark={bookmark} />
+        <BookmarkListCard
+          key={bookmark.id}
+          bookmark={bookmark}
+          showReadStatus
+        />
       ))}
     </div>
   );
@@ -148,26 +90,21 @@ const LoadingBookmarks = () => (
       >
         <div className="flex gap-6">
           <div className="flex-1 min-w-0 flex flex-col gap-2">
-            {/* Publication header skeleton - matches: flex items-center gap-2 text-sm */}
             <div className="flex items-center gap-2 text-sm">
               <div className="w-5 h-5 rounded-sm bg-gray-200 dark:bg-gray-700" />
               <div className="h-5 w-48 bg-gray-200 dark:bg-gray-700 rounded" />
             </div>
-            {/* Title skeleton - matches: text-lg sm:text-xl leading-tight line-clamp-2 */}
             <div className="space-y-1">
               <div className="h-6 sm:h-7 w-full bg-gray-200 dark:bg-gray-700 rounded" />
               <div className="h-6 sm:h-7 w-3/4 bg-gray-200 dark:bg-gray-700 rounded" />
             </div>
-            {/* Description skeleton - matches: text-sm sm:text-base leading-relaxed line-clamp-2 */}
             <div className="h-12 sm:h-14 w-full bg-gray-100 dark:bg-gray-800 rounded" />
-            {/* Tags skeleton - matches: flex flex-wrap gap-1.5 mt-1 with Badge */}
             <div className="flex flex-wrap gap-1.5 mt-1">
               <div className="h-5 w-16 bg-gray-100 dark:bg-gray-800 rounded-md" />
               <div className="h-5 w-20 bg-gray-100 dark:bg-gray-800 rounded-md" />
               <div className="h-5 w-14 bg-gray-100 dark:bg-gray-800 rounded-md" />
             </div>
           </div>
-          {/* Thumbnail skeleton - matches: w-24 h-24 sm:w-32 sm:h-32 rounded-md */}
           <div className="w-24 h-24 sm:w-32 sm:h-32 rounded-md bg-gray-200 dark:bg-gray-700 shrink-0" />
         </div>
       </article>
@@ -178,11 +115,44 @@ const LoadingBookmarks = () => (
 export default async function Index({
   searchParams,
 }: {
-  searchParams: Promise<{ collection_id?: string }>;
+  searchParams: Promise<{ collection_id?: string; read_status?: string }>;
 }) {
   const params = await searchParams;
+  const readStatus = normalizeReadStatus(params.read_status);
+
   return (
     <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+            Library
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            All saved bookmarks, including items already read.
+          </p>
+        </div>
+        <nav className="flex rounded-md border border-gray-200 bg-white p-1 text-sm dark:border-gray-800 dark:bg-gray-950">
+          {readFilters.map((filter) => {
+            const isActive = readStatus === filter.value;
+            return (
+              <Link
+                key={filter.value}
+                href={buildLibraryFilterHref(
+                  filter.value,
+                  params.collection_id
+                )}
+                className={`rounded px-3 py-1.5 font-medium transition-colors ${
+                  isActive
+                    ? "bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-300"
+                    : "text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-900"
+                }`}
+              >
+                {filter.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
       <Suspense fallback={<LoadingBookmarks />}>
         <BookmarksList searchParams={params} />
       </Suspense>

--- a/apps/web/components/bookmark/BookmarkBody.tsx
+++ b/apps/web/components/bookmark/BookmarkBody.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAppSelector, useAppDispatch } from "@/lib/store/hooks";
 import { setCurrentBookmarkFromApi } from "@/lib/store/slices/realtimeSlice";
 import { Bookmark } from "@cosmic-dolphin/api-client";
@@ -17,6 +17,7 @@ import {
   CheckIcon,
   ExternalLinkIcon,
   LockIcon,
+  RotateCcwIcon,
   Trash2Icon,
 } from "lucide-react";
 import { Action, Actions } from "@/components/ai-elements/actions";
@@ -45,6 +46,7 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { BookmarksClientAPI } from "@/lib/api/bookmarks-client";
+import { useAutoMarkBookmarkRead } from "@/lib/hooks/useAutoMarkBookmarkRead";
 
 interface ProcessingStatusProps {
   status: string;
@@ -119,6 +121,14 @@ export const BookmarkBody = (props: { bookmark: Bookmark }) => {
   const [isShared, setIsShared] = useState(
     () => (props.bookmark as any).isPublic ?? false
   );
+  const [isRead, setIsRead] = useState(
+    () => props.bookmark.isRead ?? Boolean(props.bookmark.readAt)
+  );
+  const [readAt, setReadAt] = useState<Date | undefined>(
+    () => props.bookmark.readAt
+  );
+  const [isReadLoading, setIsReadLoading] = useState(false);
+  const [suppressAutoRead, setSuppressAutoRead] = useState(false);
   const [shareUrl, setShareUrl] = useState("");
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isShareLoading, setIsShareLoading] = useState(false);
@@ -148,6 +158,12 @@ export const BookmarkBody = (props: { bookmark: Bookmark }) => {
 
   const bookmark = currentBookmark || props.bookmark;
 
+  useEffect(() => {
+    setIsRead(props.bookmark.isRead ?? Boolean(props.bookmark.readAt));
+    setReadAt(props.bookmark.readAt);
+    setSuppressAutoRead(false);
+  }, [props.bookmark.id, props.bookmark.isRead, props.bookmark.readAt]);
+
   const processingStatus =
     (bookmark as any).processingStatus ||
     (activeSession?.isLoading ? "processing" : "idle");
@@ -175,6 +191,50 @@ export const BookmarkBody = (props: { bookmark: Bookmark }) => {
       setLikeCount(previousLikeCount);
     } finally {
       setIsLikeLoading(false);
+    }
+  };
+
+  const markCurrentBookmarkRead = useCallback(async () => {
+    if (isRead || isReadLoading) return;
+
+    try {
+      const updated = await BookmarksClientAPI.markRead(bookmark.id);
+      setIsRead(updated.isRead ?? true);
+      setReadAt(updated.readAt);
+      dispatch(setCurrentBookmarkFromApi(updated));
+    } catch (error) {
+      console.error("Failed to automatically mark bookmark read:", error);
+    }
+  }, [bookmark.id, dispatch, isRead, isReadLoading]);
+
+  useAutoMarkBookmarkRead({
+    enabled: !isRead && !suppressAutoRead,
+    onMarkRead: markCurrentBookmarkRead,
+  });
+
+  const handleReadToggle = async () => {
+    if (isReadLoading) return;
+
+    const previousIsRead = isRead;
+    const previousReadAt = readAt;
+    setIsRead(!isRead);
+    setReadAt(isRead ? undefined : new Date());
+    setIsReadLoading(true);
+
+    try {
+      const updated = isRead
+        ? await BookmarksClientAPI.markUnread(bookmark.id)
+        : await BookmarksClientAPI.markRead(bookmark.id);
+      setIsRead(updated.isRead ?? !previousIsRead);
+      setReadAt(updated.readAt);
+      setSuppressAutoRead(isRead);
+      dispatch(setCurrentBookmarkFromApi(updated));
+    } catch (error) {
+      console.error("Failed to update read state:", error);
+      setIsRead(previousIsRead);
+      setReadAt(previousReadAt);
+    } finally {
+      setIsReadLoading(false);
     }
   };
 
@@ -314,6 +374,12 @@ export const BookmarkBody = (props: { bookmark: Bookmark }) => {
             </h1>
           )}
 
+          {isRead && (
+            <Badge variant="outline" className="mt-2 shrink-0">
+              Read
+            </Badge>
+          )}
+
           <Actions className="shrink-0 mt-1">
             <Action
               label={isLiked ? "Unlike" : "Like"}
@@ -348,6 +414,26 @@ export const BookmarkBody = (props: { bookmark: Bookmark }) => {
               }
             >
               <ShareIcon className="size-4" />
+            </Action>
+            <Action
+              label={isRead ? "Mark unread" : "Mark read"}
+              tooltip={isRead ? "Mark unread" : "Mark read"}
+              onClick={handleReadToggle}
+              disabled={isReadLoading}
+              variant="outline"
+              className={
+                isRead
+                  ? "text-green-600 hover:text-green-700 border-green-200 bg-green-50/50 hover:bg-green-50 dark:border-green-900/50 dark:bg-green-950/30 dark:hover:bg-green-950/50 w-auto px-3 gap-2 cursor-pointer"
+                  : "text-muted-foreground hover:text-green-600 w-auto px-3 gap-2 cursor-pointer"
+              }
+            >
+              {isReadLoading ? (
+                <Loader2Icon className="size-4 animate-spin" />
+              ) : isRead ? (
+                <RotateCcwIcon className="size-4" />
+              ) : (
+                <CheckIcon className="size-4" />
+              )}
             </Action>
             <Action
               label="Delete"

--- a/apps/web/components/bookmark/bookmark-list-card.tsx
+++ b/apps/web/components/bookmark/bookmark-list-card.tsx
@@ -1,0 +1,119 @@
+import { Bookmark } from "@cosmic-dolphin/api-client";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { LockIcon } from "lucide-react";
+import { BookmarkReadToggleButton } from "@/components/bookmark/bookmark-read-toggle-button";
+
+function extractDomain(url: string): string {
+  try {
+    const domain = new URL(url).hostname.replace("www.", "");
+    return domain;
+  } catch {
+    return "";
+  }
+}
+
+interface BookmarkListCardProps {
+  bookmark: Bookmark;
+  showReadStatus?: boolean;
+  showReadToggle?: boolean;
+}
+
+export function BookmarkListCard({
+  bookmark,
+  showReadStatus = false,
+  showReadToggle = true,
+}: BookmarkListCardProps) {
+  const immediateCollection = bookmark.collectionPath?.length
+    ? bookmark.collectionPath[bookmark.collectionPath.length - 1]
+    : null;
+  const collectionName = immediateCollection?.name;
+  const siteName =
+    bookmark.metadata?.openGraph?.siteName ||
+    extractDomain(bookmark.sourceUrl || "");
+  const image = bookmark.metadata?.openGraph?.image;
+  const description =
+    bookmark.cosmicBriefSummary ||
+    bookmark.metadata?.openGraph?.description ||
+    "";
+  const displayName = collectionName || siteName;
+  const isRead = bookmark.isRead ?? Boolean(bookmark.readAt);
+
+  return (
+    <article className="group py-6 border-b border-gray-100 dark:border-gray-800 last:border-b-0">
+      <div className="flex gap-6">
+        <div className="flex-1 min-w-0 flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            {displayName && (
+              <>
+                <div className="w-5 h-5 rounded-sm bg-gradient-to-br from-gray-700 to-gray-900 dark:from-gray-300 dark:to-gray-500 flex items-center justify-center">
+                  <span className="text-[10px] font-bold text-white dark:text-gray-900 uppercase">
+                    {displayName.charAt(0)}
+                  </span>
+                </div>
+                <span className="text-gray-600 dark:text-gray-400">
+                  In{" "}
+                  <span className="font-medium text-gray-900 dark:text-gray-100">
+                    {displayName}
+                  </span>
+                </span>
+              </>
+            )}
+            {showReadStatus && isRead && (
+              <Badge variant="outline" className="h-5 px-1.5 text-[11px]">
+                Read
+              </Badge>
+            )}
+          </div>
+
+          <Link href={`/bookmarks/${bookmark.id}`} className="block">
+            <h2 className="flex items-start gap-1.5 text-lg sm:text-xl font-bold text-gray-900 dark:text-gray-100 leading-tight line-clamp-2 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
+              {bookmark.isPrivateLink && (
+                <LockIcon className="mt-1 size-4 shrink-0 text-gray-400 dark:text-gray-500" />
+              )}
+              {bookmark.title || "Untitled"}
+            </h2>
+          </Link>
+
+          {description && (
+            <p className="text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-relaxed">
+              {description}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-1.5 mt-1">
+            {bookmark.cosmicTags?.slice(0, 3).map((tag) => (
+              <Badge
+                key={tag}
+                variant="secondary"
+                className="text-xs px-2 py-0 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+              >
+                {tag}
+              </Badge>
+            ))}
+            {showReadToggle && (
+              <BookmarkReadToggleButton
+                bookmarkId={bookmark.id}
+                initialIsRead={isRead}
+                compact
+                className="ml-auto"
+              />
+            )}
+          </div>
+        </div>
+
+        {image && (
+          <Link href={`/bookmarks/${bookmark.id}`} className="shrink-0">
+            <div className="w-24 h-24 sm:w-32 sm:h-32 rounded-md overflow-hidden bg-gray-100 dark:bg-gray-800">
+              <img
+                src={image}
+                alt=""
+                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+              />
+            </div>
+          </Link>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/components/bookmark/bookmark-read-toggle-button.tsx
+++ b/apps/web/components/bookmark/bookmark-read-toggle-button.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckIcon, Loader2Icon, RotateCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { BookmarksClientAPI } from "@/lib/api/bookmarks-client";
+import { cn } from "@/lib/utils";
+
+interface BookmarkReadToggleButtonProps {
+  bookmarkId: string;
+  initialIsRead?: boolean;
+  compact?: boolean;
+  className?: string;
+}
+
+export function BookmarkReadToggleButton({
+  bookmarkId,
+  initialIsRead = false,
+  compact = false,
+  className,
+}: BookmarkReadToggleButtonProps) {
+  const router = useRouter();
+  const [isRead, setIsRead] = useState(initialIsRead);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleToggle = async () => {
+    if (isLoading) return;
+
+    const previousIsRead = isRead;
+    setIsRead(!isRead);
+    setIsLoading(true);
+
+    try {
+      const updated = isRead
+        ? await BookmarksClientAPI.markUnread(bookmarkId)
+        : await BookmarksClientAPI.markRead(bookmarkId);
+      setIsRead(updated.isRead ?? !previousIsRead);
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to update read state:", error);
+      setIsRead(previousIsRead);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const icon = isLoading ? (
+    <Loader2Icon className="size-3.5 animate-spin" />
+  ) : isRead ? (
+    <RotateCcwIcon className="size-3.5" />
+  ) : (
+    <CheckIcon className="size-3.5" />
+  );
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size={compact ? "sm" : "default"}
+      onClick={handleToggle}
+      disabled={isLoading}
+      className={cn(
+        "h-8 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground",
+        className
+      )}
+    >
+      {icon}
+      <span>{isRead ? "Mark unread" : "Mark read"}</span>
+    </Button>
+  );
+}

--- a/apps/web/components/global-command-dialog.tsx
+++ b/apps/web/components/global-command-dialog.tsx
@@ -218,7 +218,7 @@ export function GlobalCommandDialog() {
 
         {/* Static Navigation Commands */}
         <CommandGroup heading="Navigation">
-          <CommandItem onSelect={() => handleNavigationSelect("/")}>
+          <CommandItem onSelect={() => handleNavigationSelect("/my/dashboard")}>
             <Home className="mr-2 h-4 w-4" />
             <span>Home</span>
             <CommandShortcut>⌘H</CommandShortcut>

--- a/apps/web/lib/api/__tests__/bookmarks-client.test.ts
+++ b/apps/web/lib/api/__tests__/bookmarks-client.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const { mockBookmarksRemove, mockGetSession } = vi.hoisted(() => ({
+const {
+  mockBookmarksFeed,
+  mockBookmarksList,
+  mockBookmarksMarkRead,
+  mockBookmarksMarkUnread,
+  mockBookmarksRemove,
+  mockGetSession,
+} = vi.hoisted(() => ({
+  mockBookmarksFeed: vi.fn(),
+  mockBookmarksList: vi.fn(),
+  mockBookmarksMarkRead: vi.fn(),
+  mockBookmarksMarkUnread: vi.fn(),
   mockBookmarksRemove: vi.fn(),
   mockGetSession: vi.fn(),
 }));
@@ -10,7 +21,8 @@ vi.mock("@cosmic-dolphin/api-client", () => {
   function MockBookmarksApi() {
     return {
       bookmarksRemove: mockBookmarksRemove,
-      bookmarksList: vi.fn(),
+      bookmarksFeed: mockBookmarksFeed,
+      bookmarksList: mockBookmarksList,
       bookmarksCreate: vi.fn(),
       bookmarksFindById: vi.fn(),
       bookmarksSearch: vi.fn(),
@@ -18,6 +30,8 @@ vi.mock("@cosmic-dolphin/api-client", () => {
       bookmarksUnlike: vi.fn(),
       bookmarksShare: vi.fn(),
       bookmarksUnshare: vi.fn(),
+      bookmarksMarkRead: mockBookmarksMarkRead,
+      bookmarksMarkUnread: mockBookmarksMarkUnread,
       bookmarksPreview: vi.fn(),
     };
   }
@@ -45,11 +59,66 @@ import { BookmarksClientAPI } from "../bookmarks-client";
 
 describe("BookmarksClientAPI.remove", () => {
   beforeEach(() => {
+    mockBookmarksFeed.mockReset();
+    mockBookmarksList.mockReset();
+    mockBookmarksMarkRead.mockReset();
+    mockBookmarksMarkUnread.mockReset();
     mockBookmarksRemove.mockReset();
     mockGetSession.mockReset();
     mockGetSession.mockResolvedValue({
       data: { session: { access_token: "test-token" } },
     });
+  });
+
+  it("should request the unread feed", async () => {
+    mockBookmarksFeed.mockResolvedValue({ bookmarks: [] });
+
+    const result = await BookmarksClientAPI.feed({ limit: 10, offset: 20 });
+
+    expect(mockBookmarksFeed).toHaveBeenCalledWith({ limit: 10, offset: 20 });
+    expect(result).toEqual([]);
+  });
+
+  it("should map library list query params to generated client names", async () => {
+    mockBookmarksList.mockResolvedValue({ bookmarks: [] });
+
+    await BookmarksClientAPI.list({
+      collection_id: "collection-id",
+      read_status: "read",
+      limit: 5,
+      offset: 10,
+    });
+
+    expect(mockBookmarksList).toHaveBeenCalledWith({
+      collectionId: "collection-id",
+      readStatus: "read",
+      limit: 5,
+      offset: 10,
+    });
+  });
+
+  it("should mark a bookmark read", async () => {
+    const bookmark = { id: "bookmark-123", isRead: true };
+    mockBookmarksMarkRead.mockResolvedValue(bookmark);
+
+    const result = await BookmarksClientAPI.markRead("bookmark-123");
+
+    expect(mockBookmarksMarkRead).toHaveBeenCalledWith({
+      id: "bookmark-123",
+    });
+    expect(result).toBe(bookmark);
+  });
+
+  it("should mark a bookmark unread", async () => {
+    const bookmark = { id: "bookmark-123", isRead: false };
+    mockBookmarksMarkUnread.mockResolvedValue(bookmark);
+
+    const result = await BookmarksClientAPI.markUnread("bookmark-123");
+
+    expect(mockBookmarksMarkUnread).toHaveBeenCalledWith({
+      id: "bookmark-123",
+    });
+    expect(result).toBe(bookmark);
   });
 
   describe("happy path", () => {

--- a/apps/web/lib/api/bookmarks-client.ts
+++ b/apps/web/lib/api/bookmarks-client.ts
@@ -3,6 +3,7 @@ import {
   BookmarksApi,
   CollectionsApi,
   Bookmark,
+  BookmarkReadStatus,
   Collection,
   CreateBookmarkRequest,
   CreateBookmarkResponse,
@@ -48,14 +49,35 @@ export namespace BookmarksClientAPI {
     collection_id?: string;
     limit?: number;
     offset?: number;
+    read_status?: BookmarkReadStatus;
   }): Promise<Bookmark[]> {
     const bookmarksApi = await getApiInstance();
 
     try {
-      const response = await bookmarksApi.bookmarksList(query);
+      const response = await bookmarksApi.bookmarksList({
+        collectionId: query?.collection_id,
+        limit: query?.limit,
+        offset: query?.offset,
+        readStatus: query?.read_status,
+      });
       return response.bookmarks || [];
     } catch (error) {
       console.error("Error fetching bookmarks", error);
+      return [];
+    }
+  }
+
+  export async function feed(query?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Bookmark[]> {
+    const bookmarksApi = await getApiInstance();
+
+    try {
+      const response = await bookmarksApi.bookmarksFeed(query);
+      return response.bookmarks || [];
+    } catch (error) {
+      console.error("Error fetching bookmark feed", error);
       return [];
     }
   }
@@ -127,6 +149,32 @@ export namespace BookmarksClientAPI {
       return await bookmarksApi.bookmarksUnlike({ id: bookmarkId });
     } catch (error: any) {
       console.error("Error unliking bookmark", error);
+      if (error?.response?.data?.error) {
+        throw new Error(error.response.data.error);
+      }
+      throw error;
+    }
+  }
+
+  export async function markRead(bookmarkId: string): Promise<Bookmark> {
+    const bookmarksApi = await getApiInstance();
+    try {
+      return await bookmarksApi.bookmarksMarkRead({ id: bookmarkId });
+    } catch (error: any) {
+      console.error("Error marking bookmark read", error);
+      if (error?.response?.data?.error) {
+        throw new Error(error.response.data.error);
+      }
+      throw error;
+    }
+  }
+
+  export async function markUnread(bookmarkId: string): Promise<Bookmark> {
+    const bookmarksApi = await getApiInstance();
+    try {
+      return await bookmarksApi.bookmarksMarkUnread({ id: bookmarkId });
+    } catch (error: any) {
+      console.error("Error marking bookmark unread", error);
       if (error?.response?.data?.error) {
         throw new Error(error.response.data.error);
       }

--- a/apps/web/lib/api/bookmarks.ts
+++ b/apps/web/lib/api/bookmarks.ts
@@ -1,4 +1,9 @@
-import { Configuration, BookmarksApi, Bookmark } from "@cosmic-dolphin/api-client";
+import {
+  Configuration,
+  BookmarksApi,
+  Bookmark,
+  BookmarkReadStatus,
+} from "@cosmic-dolphin/api-client";
 import { createClient } from "@/utils/supabase/server";
 
 function getApiBasePath(): string {
@@ -31,14 +36,35 @@ export namespace BookmarksAPI {
     collection_id?: string;
     limit?: number;
     offset?: number;
+    read_status?: BookmarkReadStatus;
   }): Promise<Bookmark[]> {
     const bookmarksApi = await getApiInstance();
 
     try {
-      const response = await bookmarksApi.bookmarksList(query);
+      const response = await bookmarksApi.bookmarksList({
+        collectionId: query?.collection_id,
+        limit: query?.limit,
+        offset: query?.offset,
+        readStatus: query?.read_status,
+      });
       return response.bookmarks || [];
     } catch (error) {
       console.error("Error fetching bookmarks", error);
+      return [];
+    }
+  }
+
+  export async function feed(query?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Bookmark[]> {
+    const bookmarksApi = await getApiInstance();
+
+    try {
+      const response = await bookmarksApi.bookmarksFeed(query);
+      return response.bookmarks || [];
+    } catch (error) {
+      console.error("Error fetching bookmark feed", error);
       return [];
     }
   }

--- a/apps/web/lib/hooks/useAutoMarkBookmarkRead.ts
+++ b/apps/web/lib/hooks/useAutoMarkBookmarkRead.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseAutoMarkBookmarkReadOptions {
+  enabled: boolean;
+  onMarkRead: () => Promise<void>;
+}
+
+const READ_DWELL_TIME_MS = 20_000;
+const READ_SCROLL_RATIO = 0.7;
+
+export function useAutoMarkBookmarkRead({
+  enabled,
+  onMarkRead,
+}: UseAutoMarkBookmarkReadOptions) {
+  const hasMarkedRef = useRef(false);
+  const onMarkReadRef = useRef(onMarkRead);
+
+  useEffect(() => {
+    onMarkReadRef.current = onMarkRead;
+  }, [onMarkRead]);
+
+  useEffect(() => {
+    hasMarkedRef.current = false;
+  }, [enabled]);
+
+  const markReadOnce = useCallback(async () => {
+    if (!enabled || hasMarkedRef.current) return;
+    hasMarkedRef.current = true;
+    await onMarkReadRef.current();
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const timeoutId = window.setTimeout(() => {
+      void markReadOnce();
+    }, READ_DWELL_TIME_MS);
+
+    const handleScroll = () => {
+      const documentElement = document.documentElement;
+      const scrollHeight = documentElement.scrollHeight;
+      const viewportBottom = window.scrollY + window.innerHeight;
+      const hasScrollableContent = scrollHeight > window.innerHeight;
+
+      if (!hasScrollableContent) return;
+
+      const scrollRatio = viewportBottom / scrollHeight;
+      if (scrollRatio >= READ_SCROLL_RATIO) {
+        void markReadOnce();
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [enabled, markReadOnce]);
+}

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -5,10 +5,14 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist",
+    "rootDir": "src/src",
     "typeRoots": [
       "node_modules/@types"
     ]
   },
+  "include": [
+    "src/src/**/*"
+  ],
   "exclude": [
     "dist",
     "node_modules"

--- a/packages/apispec/bookmarks.tsp
+++ b/packages/apispec/bookmarks.tsp
@@ -30,6 +30,13 @@ enum ProcessingStatus {
     failed,
 }
 
+@doc("Read-state filter for bookmark library queries")
+enum BookmarkReadStatus {
+    all,
+    unread,
+    read,
+}
+
 model Bookmark {
     id: string;
     sourceUrl: string;
@@ -50,6 +57,8 @@ model Bookmark {
     isLikedByCurrentUser?: boolean;
     isPublic?: boolean;
     shareSlug?: string;
+    readAt?: utcDateTime;
+    isRead?: boolean;
     processingStatus?: ProcessingStatus;
     processingStartedAt?: utcDateTime;
     processingCompletedAt?: utcDateTime;
@@ -126,6 +135,10 @@ model GetBookmarksQuery {
     @doc("Number of bookmarks to skip")
     @query
     offset?: int32 = 0;
+
+    @doc("Filter bookmarks by read state")
+    @query
+    read_status?: BookmarkReadStatus = BookmarkReadStatus.all;
 }
 
 model GetBookmarksResponse {
@@ -232,6 +245,18 @@ interface Bookmarks {
         @body body: BookmarkError;
     };
 
+    @doc("Get user's unread bookmark feed")
+    @useAuth(BearerAuth)
+    @get
+    @route("/feed")
+    feed(
+        @query limit?: int32 = 50,
+        @query offset?: int32 = 0,
+    ): GetBookmarksResponse | {
+        @statusCode statusCode: 500;
+        @body body: BookmarkError;
+    };
+
     @doc("Get a bookmark by ID")
     @useAuth(BearerAuth)
     @get
@@ -247,6 +272,30 @@ interface Bookmarks {
     @useAuth(BearerAuth)
     @delete
     remove(@path id: string): DeleteBookmarkResponse | {
+        @statusCode statusCode: 404;
+        @body body: BookmarkError;
+    } | {
+        @statusCode statusCode: 500;
+        @body body: BookmarkError;
+          };
+
+    @doc("Mark a bookmark as read")
+    @useAuth(BearerAuth)
+    @put
+    @route("/{id}/read")
+    markRead(@path id: string): Bookmark | {
+        @statusCode statusCode: 404;
+        @body body: BookmarkError;
+    } | {
+        @statusCode statusCode: 500;
+        @body body: BookmarkError;
+    };
+
+    @doc("Mark a bookmark as unread")
+    @useAuth(BearerAuth)
+    @delete
+    @route("/{id}/read")
+    markUnread(@path id: string): Bookmark | {
         @statusCode statusCode: 404;
         @body body: BookmarkError;
     } | {

--- a/packages/shared/src/__tests__/repositories/bookmark.repository.test.ts
+++ b/packages/shared/src/__tests__/repositories/bookmark.repository.test.ts
@@ -333,6 +333,119 @@ describe("BookmarkRepository", () => {
       expect(found.length).toBeGreaterThanOrEqual(2);
       expect(foundIds).toEqual(expect.arrayContaining([createdArchived.id, createdActive.id]));
     });
+
+    it("should filter unread bookmarks", async () => {
+      const unreadBookmark = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: null,
+      });
+      const readBookmark = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: new Date(),
+      });
+
+      const createdUnread = await repository.create(unreadBookmark);
+      const createdRead = await repository.create(readBookmark);
+
+      const found = await repository.findByUser(testUserId, {
+        readStatus: "unread",
+      });
+      const foundIds = found.map((b) => b.id);
+
+      expect(foundIds).toContain(createdUnread.id);
+      expect(foundIds).not.toContain(createdRead.id);
+      expect(found.every((b) => b.read_at === null)).toBe(true);
+    });
+
+    it("should filter read bookmarks", async () => {
+      const unreadBookmark = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: null,
+      });
+      const readBookmark = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: new Date(),
+      });
+
+      const createdUnread = await repository.create(unreadBookmark);
+      const createdRead = await repository.create(readBookmark);
+
+      const found = await repository.findByUser(testUserId, {
+        readStatus: "read",
+      });
+      const foundIds = found.map((b) => b.id);
+
+      expect(foundIds).toContain(createdRead.id);
+      expect(foundIds).not.toContain(createdUnread.id);
+      expect(found.every((b) => b.read_at !== null)).toBe(true);
+    });
+
+    it("should include both read and unread bookmarks by default", async () => {
+      const unreadBookmark = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: null,
+      });
+      const readBookmark = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: new Date(),
+      });
+
+      const createdUnread = await repository.create(unreadBookmark);
+      const createdRead = await repository.create(readBookmark);
+
+      const found = await repository.findByUser(testUserId);
+      const foundIds = found.map((b) => b.id);
+
+      expect(foundIds).toEqual(expect.arrayContaining([
+        createdUnread.id,
+        createdRead.id,
+      ]));
+    });
+  });
+
+  describe("read state", () => {
+    it("should mark a bookmark read for its owner", async () => {
+      const bookmarkData = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: null,
+      });
+      const created = await repository.create(bookmarkData);
+
+      const updated = await repository.markRead(created.id, testUserId);
+
+      expect(updated).not.toBeNull();
+      expect(updated!.id).toBe(created.id);
+      expect(updated!.read_at).toBeInstanceOf(Date);
+    });
+
+    it("should mark a bookmark unread for its owner", async () => {
+      const bookmarkData = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: new Date(),
+      });
+      const created = await repository.create(bookmarkData);
+
+      const updated = await repository.markUnread(created.id, testUserId);
+
+      expect(updated).not.toBeNull();
+      expect(updated!.id).toBe(created.id);
+      expect(updated!.read_at).toBeNull();
+    });
+
+    it("should return null when marking another user's bookmark read", async () => {
+      const bookmarkData = TestDataFactory.createBookmark({
+        user_id: testUserId,
+        read_at: null,
+      });
+      const created = await repository.create(bookmarkData);
+      const otherUserId = TestDataFactory.generateUserId();
+
+      const updated = await repository.markRead(created.id, otherUserId);
+
+      expect(updated).toBeNull();
+      const unchanged = await repository.findByIdAndUser(created.id, testUserId);
+      expect(unchanged!.read_at).toBeNull();
+    });
   });
 
   describe("update", () => {

--- a/packages/shared/src/__tests__/services/bookmark.processor.service.test.ts
+++ b/packages/shared/src/__tests__/services/bookmark.processor.service.test.ts
@@ -51,9 +51,12 @@ describe("BookmarkProcessorService", () => {
       convertToPrivateLink: jest.fn(),
       findByUserAndUrl: jest.fn(),
       findByUser: jest.fn(),
+      findFeed: jest.fn(),
       searchByQuickAccess: jest.fn(),
       share: jest.fn(),
       unshare: jest.fn(),
+      markRead: jest.fn(),
+      markUnread: jest.fn(),
       findByShareSlug: jest.fn(),
       delete: jest.fn(),
     } as jest.Mocked<BookmarkService>;

--- a/packages/shared/src/__tests__/services/bookmark.service.test.ts
+++ b/packages/shared/src/__tests__/services/bookmark.service.test.ts
@@ -23,6 +23,8 @@ describe("BookmarkService", () => {
       searchByQuickAccess: jest.fn(),
       fullTextSearch: jest.fn(),
       vectorSearch: jest.fn(),
+      markRead: jest.fn(),
+      markUnread: jest.fn(),
       update: jest.fn(),
       deleteScrapedUrlContents: jest.fn(),
       deleteByUser: jest.fn(),
@@ -288,6 +290,79 @@ describe("BookmarkService", () => {
   });
 
   describe("mapDatabaseToBookmark", () => {
+    it("should derive read fields from read_at", () => {
+      const readAt = new Date("2026-06-16T12:00:00.000Z");
+      const dbBookmark = {
+        id: "test-id",
+        source_url: "https://example.com",
+        title: "Test Title",
+        metadata: null,
+        collection_id: null,
+        user_id: testUserId,
+        is_archived: false,
+        is_favorite: false,
+        cosmic_summary: null,
+        cosmic_brief_summary: null,
+        cosmic_tags: null,
+        cosmic_images: null,
+        cosmic_links: null,
+        quick_access: null,
+        search_document: null,
+        is_private_link: false,
+        like_count: 0,
+        is_public: false,
+        share_slug: null,
+        processing_status: "idle",
+        processing_started_at: null,
+        processing_completed_at: null,
+        processing_error: null,
+        read_at: readAt,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      const mappedBookmark = (service as any).mapDatabaseToBookmark(dbBookmark);
+
+      expect(mappedBookmark.readAt).toEqual(readAt);
+      expect(mappedBookmark.isRead).toBe(true);
+    });
+
+    it("should mark bookmarks without read_at as unread", () => {
+      const dbBookmark = {
+        id: "test-id",
+        source_url: "https://example.com",
+        title: "Test Title",
+        metadata: null,
+        collection_id: null,
+        user_id: testUserId,
+        is_archived: false,
+        is_favorite: false,
+        cosmic_summary: null,
+        cosmic_brief_summary: null,
+        cosmic_tags: null,
+        cosmic_images: null,
+        cosmic_links: null,
+        quick_access: null,
+        search_document: null,
+        is_private_link: false,
+        like_count: 0,
+        is_public: false,
+        share_slug: null,
+        processing_status: "idle",
+        processing_started_at: null,
+        processing_completed_at: null,
+        processing_error: null,
+        read_at: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      const mappedBookmark = (service as any).mapDatabaseToBookmark(dbBookmark);
+
+      expect(mappedBookmark.readAt).toBeUndefined();
+      expect(mappedBookmark.isRead).toBe(false);
+    });
+
     it("should not include content field in mapped bookmark", () => {
       const dbBookmark = {
         id: "test-id",
@@ -319,6 +394,99 @@ describe("BookmarkService", () => {
       expect(mappedBookmark.title).toBe(dbBookmark.title);
       expect(mappedBookmark.userId).toBe(dbBookmark.user_id);
       expect(mappedBookmark).not.toHaveProperty("content");
+    });
+  });
+
+  describe("read state", () => {
+    it("should mark a bookmark read for the owning user", async () => {
+      const readAt = new Date("2026-06-16T12:00:00.000Z");
+      const dbBookmark = {
+        id: "bookmark-id",
+        source_url: "https://example.com",
+        title: "Read bookmark",
+        metadata: null,
+        collection_id: null,
+        user_id: testUserId,
+        is_archived: false,
+        is_favorite: false,
+        cosmic_summary: null,
+        cosmic_brief_summary: null,
+        cosmic_tags: null,
+        cosmic_images: null,
+        cosmic_links: null,
+        quick_access: null,
+        search_document: null,
+        is_private_link: false,
+        like_count: 0,
+        is_public: false,
+        share_slug: null,
+        processing_status: "idle",
+        processing_started_at: null,
+        processing_completed_at: null,
+        processing_error: null,
+        read_at: readAt,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      mockRepository.markRead.mockResolvedValue(dbBookmark as any);
+
+      const result = await service.markRead("bookmark-id", testUserId);
+
+      expect(mockRepository.markRead).toHaveBeenCalledWith(
+        "bookmark-id",
+        testUserId
+      );
+      expect(result.isRead).toBe(true);
+      expect(result.readAt).toEqual(readAt);
+    });
+
+    it("should throw Bookmark not found when marking read fails ownership check", async () => {
+      mockRepository.markRead.mockResolvedValue(null);
+
+      await expect(service.markRead("bookmark-id", testUserId)).rejects.toThrow(
+        "Bookmark not found"
+      );
+    });
+
+    it("should clear read state when marking unread", async () => {
+      const dbBookmark = {
+        id: "bookmark-id",
+        source_url: "https://example.com",
+        title: "Unread bookmark",
+        metadata: null,
+        collection_id: null,
+        user_id: testUserId,
+        is_archived: false,
+        is_favorite: false,
+        cosmic_summary: null,
+        cosmic_brief_summary: null,
+        cosmic_tags: null,
+        cosmic_images: null,
+        cosmic_links: null,
+        quick_access: null,
+        search_document: null,
+        is_private_link: false,
+        like_count: 0,
+        is_public: false,
+        share_slug: null,
+        processing_status: "idle",
+        processing_started_at: null,
+        processing_completed_at: null,
+        processing_error: null,
+        read_at: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      mockRepository.markUnread.mockResolvedValue(dbBookmark as any);
+
+      const result = await service.markUnread("bookmark-id", testUserId);
+
+      expect(mockRepository.markUnread).toHaveBeenCalledWith(
+        "bookmark-id",
+        testUserId
+      );
+      expect(result.isRead).toBe(false);
+      expect(result.readAt).toBeUndefined();
     });
   });
 

--- a/packages/shared/src/database/schema.ts
+++ b/packages/shared/src/database/schema.ts
@@ -45,6 +45,7 @@ export interface BookmarksTable extends BaseTable {
   like_count: Generated<number>;
   is_public: Generated<boolean>;
   share_slug: string | null;
+  read_at: Date | null;
 }
 
 // Bookmark likes table (user x bookmark junction)

--- a/packages/shared/src/repositories/bookmark.repository.ts
+++ b/packages/shared/src/repositories/bookmark.repository.ts
@@ -14,6 +14,7 @@ export interface FindByUserOptions {
   limit?: number;
   offset?: number;
   includeArchived?: boolean;
+  readStatus?: "all" | "unread" | "read";
 }
 
 export interface SearchOptions {
@@ -67,6 +68,8 @@ export interface BookmarkRepository {
     options?: SearchOptions
   ): Promise<VectorSearchResult[]>;
   findByShareSlug(slug: string): Promise<Bookmark | null>;
+  markRead(id: string, userId: string): Promise<Bookmark | null>;
+  markUnread(id: string, userId: string): Promise<Bookmark | null>;
   update(id: string, data: BookmarkUpdate): Promise<Bookmark>;
   deleteByUser(id: string, userId: string): Promise<boolean>;
 }
@@ -214,6 +217,7 @@ export class BookmarkRepositoryImpl
         limit = 50,
         offset = 0,
         includeArchived = false,
+        readStatus = "all",
       } = options;
 
       let query = this.db
@@ -230,6 +234,12 @@ export class BookmarkRepositoryImpl
 
       if (collectionId) {
         query = query.where("collection_id", "=", collectionId);
+      }
+
+      if (readStatus === "unread") {
+        query = query.where("read_at", "is", null);
+      } else if (readStatus === "read") {
+        query = query.where("read_at", "is not", null);
       }
 
       return await query.execute();
@@ -274,6 +284,34 @@ export class BookmarkRepositoryImpl
 
       return result;
     }, "update");
+  }
+
+  async markRead(id: string, userId: string): Promise<Bookmark | null> {
+    return this.executeQuery(async () => {
+      const result = await this.db
+        .updateTable("bookmarks")
+        .set({ read_at: new Date() })
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .returningAll()
+        .executeTakeFirst();
+
+      return result || null;
+    }, "markRead");
+  }
+
+  async markUnread(id: string, userId: string): Promise<Bookmark | null> {
+    return this.executeQuery(async () => {
+      const result = await this.db
+        .updateTable("bookmarks")
+        .set({ read_at: null })
+        .where("id", "=", id)
+        .where("user_id", "=", userId)
+        .returningAll()
+        .executeTakeFirst();
+
+      return result || null;
+    }, "markUnread");
   }
 
   async deleteByUser(id: string, userId: string): Promise<boolean> {

--- a/packages/shared/src/services/bookmark.service.ts
+++ b/packages/shared/src/services/bookmark.service.ts
@@ -43,6 +43,7 @@ export interface BookmarkService {
     metadata: PrivateLinkMetadata
   ): Promise<Bookmark>;
   findByUser(userId: string, options?: FindByUserOptions): Promise<Bookmark[]>;
+  findFeed(userId: string, options?: FindByUserOptions): Promise<Bookmark[]>;
   searchByQuickAccess(
     userId: string,
     query: string,
@@ -56,6 +57,8 @@ export interface BookmarkService {
   ): Promise<Bookmark>;
   share(bookmarkId: string, userId: string): Promise<ShareBookmarkResponse>;
   unshare(bookmarkId: string, userId: string): Promise<ShareBookmarkResponse>;
+  markRead(bookmarkId: string, userId: string): Promise<Bookmark>;
+  markUnread(bookmarkId: string, userId: string): Promise<Bookmark>;
   findByShareSlug(slug: string): Promise<Bookmark | null>;
   delete(id: string, userId: string): Promise<void>;
 }
@@ -211,6 +214,17 @@ export class BookmarkServiceImpl implements BookmarkService {
     return this.enrichManyWithCollectionInfo(mapped);
   }
 
+  async findFeed(
+    userId: string,
+    options: FindByUserOptions = {}
+  ): Promise<Bookmark[]> {
+    return this.findByUser(userId, {
+      ...options,
+      readStatus: "unread",
+      includeArchived: false,
+    });
+  }
+
   async update(
     id: string,
     data: Partial<
@@ -248,6 +262,25 @@ export class BookmarkServiceImpl implements BookmarkService {
     if (!deleted) {
       throw new Error("Bookmark not found");
     }
+  }
+
+  async markRead(bookmarkId: string, userId: string): Promise<Bookmark> {
+    const bookmark = await this.bookmarkRepository.markRead(bookmarkId, userId);
+    if (!bookmark) {
+      throw new Error("Bookmark not found");
+    }
+    return this.mapDatabaseToBookmark(bookmark);
+  }
+
+  async markUnread(bookmarkId: string, userId: string): Promise<Bookmark> {
+    const bookmark = await this.bookmarkRepository.markUnread(
+      bookmarkId,
+      userId
+    );
+    if (!bookmark) {
+      throw new Error("Bookmark not found");
+    }
+    return this.mapDatabaseToBookmark(bookmark);
   }
 
   async updateProcessingStatus(
@@ -425,6 +458,8 @@ export class BookmarkServiceImpl implements BookmarkService {
       likeCount: data.like_count ?? 0,
       isPublic: data.is_public ?? false,
       shareSlug: data.share_slug ?? undefined,
+      readAt: data.read_at ? new Date(data.read_at) : undefined,
+      isRead: data.read_at != null,
       processingStatus: data.processing_status || "idle",
       processingStartedAt: data.processing_started_at
         ? new Date(data.processing_started_at)

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -119,6 +119,8 @@ export interface Bookmark extends BaseEntity {
   isLikedByCurrentUser?: boolean;
   isPublic: boolean;
   shareSlug?: string;
+  readAt?: Date;
+  isRead?: boolean;
   processingStatus: ProcessingStatus;
   processingStartedAt?: Date;
   processingCompletedAt?: Date;
@@ -205,6 +207,7 @@ export interface GetBookmarksQuery {
   collection_id?: string;
   limit?: number;
   offset?: number;
+  read_status?: "all" | "unread" | "read";
 }
 
 export interface GetBookmarksResponse {

--- a/supabase/migrations/20260617000001_add_bookmark_read_state.sql
+++ b/supabase/migrations/20260617000001_add_bookmark_read_state.sql
@@ -1,0 +1,7 @@
+ALTER TABLE bookmarks
+  ADD COLUMN read_at timestamptz;
+
+CREATE INDEX idx_bookmarks_read_at ON bookmarks(read_at);
+CREATE INDEX idx_bookmarks_user_unread
+  ON bookmarks(user_id, created_at DESC)
+  WHERE read_at IS NULL AND is_archived = false;


### PR DESCRIPTION
## Summary
- Add persistent bookmark read-state storage and API support
- Expose read-state operations through the generated contract and clients
- Update web and mobile bookmark views with read toggles and automatic marking
- Add coverage for bookmark routes, repositories, services, and client behavior

## Testing
- Added and updated unit tests for API routes, shared bookmark logic, and web API clients